### PR TITLE
Add login system with credit checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -421,6 +421,7 @@ function renderHistory(){}
 
 // =================== EVENTOS ===================
 processBtn.addEventListener("click", () => {
+  if (window.Auth) Auth.consumeCredit();
   const pasted = inputText.value || "";
 
   const aiFromPasted = extractAccountIdentifierFromHtml(pasted);

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,43 @@
+const SESSION_KEY = 'userSession';
+
+function getSession(){
+  try {
+    return JSON.parse(localStorage.getItem(SESSION_KEY)) || null;
+  } catch {
+    return null;
+  }
+}
+
+function setSession(session){
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+}
+
+function clearSession(){
+  localStorage.removeItem(SESSION_KEY);
+}
+
+function requireSession(){
+  const session = getSession();
+  if (!session || !session.user || session.credits <= 0){
+    clearSession();
+    window.location.href = 'login.html';
+    return null;
+  }
+  return session;
+}
+
+function consumeCredit(){
+  const session = requireSession();
+  if (!session) return;
+  session.credits -= 1;
+  if (session.credits <= 0){
+    alert('Se acabaron tus créditos');
+    clearSession();
+    window.location.href = 'login.html';
+    return;
+  }
+  setSession(session);
+}
+
+// Export helpers for other scripts
+window.Auth = { getSession, setSession, clearSession, requireSession, consumeCredit };

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
 
   <!-- Estilos -->
   <link rel="stylesheet" href="styles.css"/>
+  <script src="auth.js"></script>
+  <script>
+    Auth.requireSession();
+  </script>
 </head>
 <body>
   <!-- MODAL: Guía -->

--- a/login.css
+++ b/login.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  margin: 0;
+}
+
+.login-wrapper {
+  width: 320px;
+}
+
+.login-card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.login-card h2 {
+  margin: 0 0 10px;
+  text-align: center;
+}
+
+.login-card label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.login-card input {
+  padding: 8px;
+  font-size: 14px;
+}
+
+.login-card button {
+  padding: 10px;
+  background: #0ea5e9;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/login.html
+++ b/login.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Iniciar sesión</title>
+  <link rel="stylesheet" href="login.css" />
+</head>
+<body>
+  <div class="login-wrapper">
+    <form id="loginForm" class="login-card">
+      <h2>Iniciar sesión</h2>
+      <label>
+        <span>Usuario</span>
+        <input type="text" id="username" required />
+      </label>
+      <label>
+        <span>Contraseña</span>
+        <input type="password" id="password" required />
+      </label>
+      <button type="submit">Entrar</button>
+    </form>
+  </div>
+  <script src="auth.js"></script>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e){
+      e.preventDefault();
+      const user = document.getElementById('username').value.trim();
+      const pass = document.getElementById('password').value.trim();
+      if(user && pass){
+        Auth.setSession({ user: user, credits: 3 });
+        window.location.href = 'index.html';
+      } else {
+        alert('Credenciales inválidas');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enforce session and credit validation before loading the main app
- add login page with independent CSS styling
- consume credits when processing text to prevent bypass on refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7da0520e08330b68675998596174b