### PR TITLE
Add login system with credit checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -421,6 +421,7 @@ function renderHistory(){}
 
 // =================== EVENTOS ===================
 processBtn.addEventListener("click", () => {
+  if (window.Auth) Auth.consumeCredit();
   const pasted = inputText.value || "";
 
   const aiFromPasted = extractAccountIdentifierFromHtml(pasted);

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,55 @@
+const SESSION_KEY = 'userSession';
+
+function getSession(){
+  try {
+    return JSON.parse(localStorage.getItem(SESSION_KEY)) || null;
+  } catch {
+    return null;
+  }
+}
+
+function setSession(session){
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  updateUI();
+}
+
+function clearSession(){
+  localStorage.removeItem(SESSION_KEY);
+  updateUI();
+}
+
+function requireSession(){
+  const session = getSession();
+  if (!session || !session.user || session.credits <= 0){
+    clearSession();
+    window.location.href = 'login.html';
+    return null;
+  }
+  return session;
+}
+
+function consumeCredit(){
+  const session = requireSession();
+  if (!session) return;
+  session.credits -= 1;
+  if (session.credits <= 0){
+    alert('Se acabaron tus créditos');
+    clearSession();
+    window.location.href = 'login.html';
+    return;
+  }
+  setSession(session);
+}
+
+function updateUI(){
+  const session = getSession();
+  const creditEl = document.getElementById('creditCount');
+  const planEl = document.getElementById('planName');
+  const userEl = document.getElementById('userName');
+  if (creditEl) creditEl.textContent = session ? session.credits : '-';
+  if (planEl) planEl.textContent = session ? (session.plan || '-') : '-';
+  if (userEl) userEl.textContent = session ? session.user : '';
+}
+
+// Export helpers for other scripts
+window.Auth = { getSession, setSession, clearSession, requireSession, consumeCredit, updateUI };

--- a/index.html
+++ b/index.html
@@ -13,8 +13,20 @@
 
   <!-- Estilos -->
   <link rel="stylesheet" href="styles.css"/>
-</head>
-<body>
+  <script src="auth.js"></script>
+  <script>
+    const session = Auth.requireSession();
+    window.addEventListener('DOMContentLoaded', () => {
+      Auth.updateUI();
+      const logoutBtn = document.getElementById('logoutBtn');
+      if (logoutBtn) logoutBtn.addEventListener('click', () => {
+        Auth.clearSession();
+        window.location.href = 'login.html';
+      });
+    });
+    </script>
+  </head>
+  <body>
   <!-- MODAL: Guía -->
   <div id="modalOverlay" class="modal-overlay" aria-hidden="true"></div>
   <div id="howtoModal" class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-desc">
@@ -80,6 +92,16 @@
 
         <div class="row actions one-line">
           <button id="openGuide" class="btn ghost">Guía ( ? )</button>
+        </div>
+      </div>
+      <div class="row session-row">
+        <div class="session-info">
+          <span id="userName"></span>
+          <span>Plan: <span id="planName"></span></span>
+          <span>Créditos: <span id="creditCount"></span></span>
+        </div>
+        <div class="row actions one-line">
+          <button id="logoutBtn" class="btn ghost">Cerrar sesión</button>
         </div>
       </div>
     </section>

--- a/login.css
+++ b/login.css
@@ -1,0 +1,91 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #0ea5e9, #174ea6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  margin: 0;
+  color: #fff;
+}
+
+.login-wrapper {
+  width: 320px;
+}
+
+.login-card {
+  background: rgba(255,255,255,0.1);
+  backdrop-filter: blur(4px);
+  padding: 24px 28px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-card .title {
+  margin: 0 0 12px;
+  text-align: center;
+  font-size: 20px;
+}
+
+.login-card label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.login-card input {
+  padding: 8px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: none;
+}
+
+.login-card button {
+  padding: 10px;
+  background: #0ea5e9;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.error {
+  color: #ffd1d1;
+  font-size: 13px;
+  text-align: center;
+  min-height: 18px;
+}
+
+.loading {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #fff;
+  font-size: 16px;
+}
+
+.loader {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.hidden {
+  display: none;
+}

--- a/login.html
+++ b/login.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Iniciar sesión</title>
+  <link rel="stylesheet" href="login.css" />
+</head>
+<body>
+  <div class="login-wrapper">
+    <form id="loginForm" class="login-card">
+      <h1 class="title">Extractor WA Premium</h1>
+      <label>
+        <span>Usuario</span>
+        <input type="text" id="username" required />
+      </label>
+      <label>
+        <span>Contraseña</span>
+        <input type="password" id="password" required />
+      </label>
+      <button type="submit" id="loginBtn">Entrar</button>
+      <div id="errorMsg" class="error"></div>
+    </form>
+  </div>
+  <div id="loading" class="loading hidden">
+    <div class="loader"></div>
+    <p id="loadingText">Cargando...</p>
+  </div>
+  <script src="auth.js"></script>
+  <script>
+    const USERS = {
+      demo:    { password: 'demo',    credits: 3, plan: 'Gratis'   },
+      premium: { password: '1234',    credits: 10, plan: 'Premium' }
+    };
+
+    const form = document.getElementById('loginForm');
+    const btn = document.getElementById('loginBtn');
+    const err = document.getElementById('errorMsg');
+    const loading = document.getElementById('loading');
+    const loadingText = document.getElementById('loadingText');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      err.textContent = '';
+      const user = document.getElementById('username').value.trim();
+      const pass = document.getElementById('password').value.trim();
+      const record = USERS[user];
+      if (record && record.password === pass){
+        btn.disabled = true;
+        loadingText.innerHTML = `Plan: ${record.plan} &middot; Créditos: ${record.credits}`;
+        loading.classList.remove('hidden');
+        Auth.setSession({ user, credits: record.credits, plan: record.plan });
+        setTimeout(()=>{ window.location.href = 'index.html'; }, 800);
+      } else {
+        err.textContent = 'Credenciales inválidas';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -654,6 +654,8 @@ body[data-theme="light"] .modal-overlay{ background:rgba(0,0,0,.32) }
    ========================= */
 .topbar + .grid{ margin-top:clamp(8px,1.5vh,18px) }
 .topbar .row .actions.one-line{ margin-left:auto; justify-content:flex-end }
+.topbar .session-row{ margin-top:8px; }
+.session-info{ display:flex; gap:12px; font-size:14px; }
 
 /* =========================
    Scrollbars globales


### PR DESCRIPTION
## Summary
- redesign login page with gradient styling, validation and loading overlay showing plan and credits
- display current plan and remaining credits in top bar with logout button
- update auth helper to refresh UI when session data changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7da0520e08330b68675998596174b