### PR TITLE
Fix login layout, graph responsiveness, and add admin access

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       <p id="loginLoading" class="loading-msg">Iniciando sesión...</p>
       <p id="loginError" class="error-msg"></p>
     </form>
+    <button id="adminAccessBtn" type="button" class="admin-access-btn">Ingreso administrado</button>
   </div>
 
   <div id="sessionToast" class="session-toast" role="status" aria-live="polite" aria-hidden="true"></div>

--- a/js/app-core.js
+++ b/js/app-core.js
@@ -1645,6 +1645,21 @@ if (graphRefreshBtn){
   });
 }
 
+let graphResizeTimer = null;
+if (typeof window !== 'undefined'){
+  window.addEventListener('resize', () => {
+    if (!graphNetwork) return;
+    if (graphResizeTimer) clearTimeout(graphResizeTimer);
+    graphResizeTimer = setTimeout(() => {
+      graphResizeTimer = null;
+      try {
+        graphNetwork.redraw();
+        graphNetwork.fit({ animation: { duration: 300, easingFunction: 'easeInOutQuad' } });
+      } catch {}
+    }, 160);
+  });
+}
+
 setGraphControlsEnabled(false);
 
 async function requestCredit(){

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,27 @@
 // main.js
+const ADMIN_EMAIL = 'stikmena6@gmail.com';
+const ADMIN_PORTAL_URL = 'https://stikmena23-alt.github.io/wf-toolsadmin/';
+
+function setupAdminAccess(){
+  const adminBtn = document.getElementById('adminAccessBtn');
+  if (!adminBtn) return;
+  adminBtn.addEventListener('click', () => {
+    const input = prompt('Ingresa el correo de administrador');
+    if (!input) return;
+    if (input.trim().toLowerCase() === ADMIN_EMAIL) {
+      const adminWindow = window.open(ADMIN_PORTAL_URL, '_blank');
+      if (adminWindow) {
+        adminWindow.opener = null;
+      }
+    } else {
+      alert('Correo de administrador no válido.');
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
+    setupAdminAccess();
     window.AppCore?.init();
     if (window.Auth?.init) {
       await window.Auth.init();

--- a/styles.css
+++ b/styles.css
@@ -1224,14 +1224,29 @@ body[data-theme="light"] .table thead th{
 .chat-log p.bot{ color:var(--text-1); }
 .chat-input{ display:flex; gap:8px; }
 .chat-input input{ flex:1; }
-#graph{ height:400px; }
+
+#graphPanel{
+  display:flex;
+  flex-direction:column;
+  gap:var(--gap);
+}
+
+#graph{
+  position:relative;
+  width:100%;
+  min-height:clamp(320px, 35vh, 440px);
+  border:1px solid var(--border);
+  border-radius:var(--radius-sm);
+  background:var(--surface-0);
+  overflow:hidden;
+}
 
 .graph-top{
   display:flex;
-  align-items:flex-start;
+  align-items:center;
   justify-content:space-between;
   gap:var(--gap);
-  margin-bottom:var(--gap);
+  margin-bottom:0;
   flex-wrap:wrap;
 }
 
@@ -1240,6 +1255,8 @@ body[data-theme="light"] .table thead th{
   align-items:center;
   gap:10px;
   flex-wrap:wrap;
+  margin-left:auto;
+  justify-content:flex-end;
 }
 
 .graph-label{
@@ -1345,7 +1362,8 @@ body[data-theme="light"] .graph-refresh{ color:#0a223d; }
 
 #graphPanel.fullscreen #graph{
   flex:1 1 auto;
-  height:auto;
+  height:100%;
+  min-height:clamp(480px, 70vh, 820px);
 }
 
 #graphPanel.fullscreen .graph-fullscreen-btn{
@@ -1366,7 +1384,7 @@ body[data-theme="light"] .graph-refresh{ color:#0a223d; }
   box-shadow:0 0 0 3px rgba(239,68,68,.35);
 }
 
-.color-controls{ display:none; gap:8px; flex-wrap:wrap; margin-bottom:var(--gap); }
+.color-controls{ display:none; gap:8px; flex-wrap:wrap; margin-bottom:0; }
 #graphPanel.fullscreen .color-controls{ display:flex; }
 .color-item{ display:flex; align-items:center; gap:4px; }
 .color-item input{ width:40px; height:24px; padding:0; border:none; background:transparent; }
@@ -1505,14 +1523,18 @@ body[data-theme="light"] .session-modal-icon{
 .login-screen{
   position:fixed;
   inset:0;
-  display:grid;
-  place-items:center;
+  display:flex;
+  align-items:center;
+  justify-content:center;
   padding:clamp(24px, 6vw, 60px);
   background:
     radial-gradient(70vw 60vh at -15% -15%, rgba(4,26,64,.72), transparent 65%),
     radial-gradient(65vw 60vh at 125% 10%, rgba(2,24,51,.68), transparent 60%),
     linear-gradient(140deg, var(--bg1), var(--bg2));
   z-index:1000;
+  min-height:100vh;
+  width:100%;
+  overflow:auto;
 }
 
 .login-card{
@@ -1635,5 +1657,63 @@ body[data-theme="light"] .session-modal-icon{
   color: var(--danger);
   font-weight:700;
   display:none;
+}
+
+.admin-access-btn{
+  position:absolute;
+  right:clamp(20px, 6vw, 48px);
+  bottom:clamp(20px, 6vh, 48px);
+  padding:12px 20px;
+  border-radius:999px;
+  border:1px solid rgba(148,163,184,.45);
+  background: linear-gradient(135deg, rgba(14,165,233,.28), rgba(3,105,161,.42));
+  color:#e2f3ff;
+  font-weight:700;
+  cursor:pointer;
+  box-shadow:0 14px 36px rgba(14,165,233,.28);
+  transition:transform .12s ease, box-shadow .18s ease, background .18s ease;
+  z-index:1010;
+}
+
+.admin-access-btn:hover{
+  transform:translateY(-1px);
+  box-shadow:0 18px 44px rgba(14,165,233,.32);
+}
+
+.admin-access-btn:focus-visible{
+  outline:3px solid rgba(14,165,233,.55);
+  outline-offset:3px;
+}
+
+.admin-access-btn:active{
+  transform:translateY(0);
+}
+
+[data-theme="light"] .admin-access-btn{
+  background: linear-gradient(135deg, rgba(14,165,233,.18), rgba(3,105,161,.28));
+  color:#0a223d;
+  border-color:rgba(14,165,233,.35);
+  box-shadow:0 14px 36px rgba(14,165,233,.18);
+}
+
+@media (max-width:600px){
+  .admin-access-btn{
+    left:50%;
+    right:auto;
+    transform:translateX(-50%);
+    bottom:clamp(16px, 6vh, 32px);
+  }
+
+  .admin-access-btn:hover{
+    transform:translateX(-50%) translateY(-1px);
+  }
+
+  .admin-access-btn:focus-visible{
+    transform:translateX(-50%);
+  }
+
+  .admin-access-btn:active{
+    transform:translateX(-50%) translateY(0);
+  }
 }
 


### PR DESCRIPTION
## Summary
- keep the login overlay anchored in the center and add a floating "Ingreso administrado" button for the protected admin portal
- restyle the relations graph container so its controls align consistently and the canvas keeps its size in both normal and fullscreen views
- ensure the graph re-renders on viewport changes and gate the admin shortcut with an email prompt

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9f79c522083308daf20853d9ac328