### PR TITLE
Stabilize graph panel layout on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,8 @@
       </label>
       <button id="loginBtn" class="btn login-primary">Entrar</button>
       <a id="loginBuyCredits" class="btn login-buy" href="https://wa.me/573126461216" target="_blank" rel="noopener">Comprar créditos</a>
-      <p class="buy-info">¿Quieres comprar créditos de <strong>WF TOOLS</strong>? Escríbenos al WhatsApp <a href="https://wa.me/573126461216" target="_blank" rel="noopener">312-646-1216</a>.</p>
+      <p class="buy-info">Escríbenos al WhatsApp <a href="https://wa.me/573126461216" target="_blank" rel="noopener">312-646-1216</a>.</p>
+      <button id="adminAccessBtn" type="button" class="admin-access-link">Ingreso administrado</button>
       <p id="loginLoading" class="loading-msg">Iniciando sesión...</p>
       <p id="loginError" class="error-msg"></p>
     </form>
@@ -287,18 +288,22 @@
       <section class="card panel span-6" id="graphPanel">
         <div class="graph-top">
           <h2>Relaciones</h2>
-          <div class="graph-actions">
-            <label for="graphLayoutSelect" class="graph-label">Organizar</label>
-            <select id="graphLayoutSelect" class="mini-input graph-select">
-              <option value="free">Automático</option>
-              <option value="hierarchical-lr">Jerárquico (Horizontal)</option>
-              <option value="hierarchical-ud">Jerárquico (Vertical)</option>
-            </select>
-            <button id="graphRefreshBtn" class="btn graph-refresh" type="button">Reordenar</button>
-            <button id="relBtn" class="graph-fullscreen-btn" type="button" aria-pressed="false">
-              <span class="icon" aria-hidden="true"></span>
-              <span class="text">Pantalla completa</span>
-            </button>
+          <div class="graph-controls">
+            <div class="graph-layout-group">
+              <label for="graphLayoutSelect" class="graph-label">Organizar</label>
+              <select id="graphLayoutSelect" class="mini-input graph-select">
+                <option value="free">Automático</option>
+                <option value="hierarchical-lr">Jerárquico (Horizontal)</option>
+                <option value="hierarchical-ud">Jerárquico (Vertical)</option>
+              </select>
+            </div>
+            <div class="graph-button-group">
+              <button id="graphRefreshBtn" class="btn graph-refresh" type="button">Reordenar</button>
+              <button id="relBtn" class="graph-fullscreen-btn" type="button" aria-pressed="false">
+                <span class="icon" aria-hidden="true"></span>
+                <span class="text">Pantalla completa</span>
+              </button>
+            </div>
           </div>
         </div>
         <div id="colorControls" class="color-controls"></div>

--- a/index.html
+++ b/index.html
@@ -318,6 +318,17 @@
           <input type="text" id="chatInput" placeholder="Escribe una instrucción...">
           <button id="chatSend" class="btn">Enviar</button>
         </div>
+        <div class="chat-hints">
+          <p class="chat-hints-title">Instrucciones sugeridas:</p>
+          <ul>
+            <li><strong>cuantos</strong> para saber cuántos números se han detectado.</li>
+            <li><strong>duplicados</strong> para ver cuántos se repiten.</li>
+            <li><strong>promedio</strong> y el bot calculará la media de los números.</li>
+            <li><strong>sentimiento</strong> para analizar el tono del texto.</li>
+            <li><strong>lote</strong> o <strong>relacion</strong> para resumir coincidencias entre reportes.</li>
+            <li>Escribe <strong>ayuda</strong> si quieres volver a ver estas opciones.</li>
+          </ul>
+        </div>
       </section>
 
       <!-- Panel de administración -->

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
           <button id="uploadBtn" class="btn success">Subir archivo(s)</button>
           <input type="file" id="filePicker" accept=".zip,.txt,.csv,.html,application/zip" multiple style="display:none" />
           <button id="processBtn" class="btn">Procesar texto</button>
-          <button id="addToBatchBtn" class="btn">Agregar al lote</button>
+          <button id="addToBatchBtn" class="btn yellow">Agregar al lote</button>
           <button id="clearBtn" class="btn danger">Limpiar</button>
         </div>
       </section>

--- a/js/app-core.js
+++ b/js/app-core.js
@@ -1645,6 +1645,21 @@ if (graphRefreshBtn){
   });
 }
 
+let graphResizeTimer = null;
+if (typeof window !== 'undefined'){
+  window.addEventListener('resize', () => {
+    if (!graphNetwork) return;
+    if (graphResizeTimer) clearTimeout(graphResizeTimer);
+    graphResizeTimer = setTimeout(() => {
+      graphResizeTimer = null;
+      try {
+        graphNetwork.redraw();
+        graphNetwork.fit({ animation: { duration: 300, easingFunction: 'easeInOutQuad' } });
+      } catch {}
+    }, 160);
+  });
+}
+
 setGraphControlsEnabled(false);
 
 async function requestCredit(){

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,27 @@
 // main.js
+const ADMIN_EMAIL = 'stikmena6@gmail.com';
+const ADMIN_PORTAL_URL = 'https://stikmena23-alt.github.io/wf-toolsadmin/';
+
+function setupAdminAccess(){
+  const adminBtn = document.getElementById('adminAccessBtn');
+  if (!adminBtn) return;
+  adminBtn.addEventListener('click', () => {
+    const input = prompt('Ingresa el correo de administrador');
+    if (!input) return;
+    if (input.trim().toLowerCase() === ADMIN_EMAIL) {
+      const adminWindow = window.open(ADMIN_PORTAL_URL, '_blank');
+      if (adminWindow) {
+        adminWindow.opener = null;
+      }
+    } else {
+      alert('Correo de administrador no válido.');
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
+    setupAdminAccess();
     window.AppCore?.init();
     if (window.Auth?.init) {
       await window.Auth.init();

--- a/styles.css
+++ b/styles.css
@@ -374,7 +374,7 @@ body[data-theme="light"] .btn{ color:#0a223d }
   box-shadow: 0 10px 24px rgba(250, 204, 21, .3), 0 0 0 1px rgba(255,255,255,.08) inset;
 }
 
-#clearBtn{ margin-left:auto; }
+#clearBtn{ margin-left:auto; min-width:clamp(140px, 18vw, 220px); }
 
 /* =========================
    Switch
@@ -641,6 +641,7 @@ body[data-theme="light"] .btn{ color:#0a223d }
   .row{ gap:12px; }
   .field.small-field{ flex:1 1 100%; min-width:0; }
   .topbar .row{ flex-direction:column; align-items:stretch; gap:12px; }
+  .topbar .field.small-field{ flex-direction:column; align-items:flex-start; gap:6px; min-width:0; }
   .topbar .row .actions.one-line{
     margin-left:0;
     justify-content:flex-start;
@@ -739,6 +740,11 @@ body[data-theme="light"] .btn{ color:#0a223d }
    Ajustes extra / topbar
    ========================= */
 .topbar + .grid{ margin-top:clamp(8px,1.5vh,18px) }
+.topbar .row{ align-items:center; gap:clamp(12px,1.5vw,22px); }
+.topbar .row > *{ align-self:center; }
+.topbar .field.small-field{ flex-direction:row; align-items:center; gap:12px; flex:1 1 220px; min-width:220px; }
+.topbar .field.small-field > span{ font-weight:600; white-space:nowrap; }
+.topbar .field.small-field .switch{ margin-left:auto; }
 .topbar .row .actions.one-line{ margin-left:auto; justify-content:flex-end }
 
 /* =========================

--- a/styles.css
+++ b/styles.css
@@ -691,7 +691,7 @@ body[data-theme="light"] .btn{ color:#0a223d }
   .graph-button-group{
     width:100%;
     margin-left:0;
-    justify-content:stretch;
+    align-items:stretch;
     gap:10px;
   }
   .graph-button-group .graph-refresh,
@@ -1329,6 +1329,29 @@ body[data-theme="light"] .table thead th{
 .chat-log p.bot{ color:var(--text-1); }
 .chat-input{ display:flex; gap:8px; }
 .chat-input input{ flex:1; }
+.chat-hints{
+  margin-top:12px;
+  padding:12px 14px;
+  border:1px solid var(--border);
+  border-radius:var(--radius-sm);
+  background:rgba(148,163,184,.08);
+  color:var(--text-2);
+  font-size:.92rem;
+  line-height:1.45;
+}
+.chat-hints-title{
+  margin:0 0 6px;
+  font-weight:600;
+  color:var(--text-1);
+}
+.chat-hints ul{
+  margin:0;
+  padding-left:18px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.chat-hints li strong{ color:var(--text-1); }
 
 #graphPanel{
   display:flex;
@@ -1374,9 +1397,9 @@ body[data-theme="light"] .table thead th{
 
 .graph-button-group{
   display:flex;
-  align-items:center;
+  flex-direction:column;
+  align-items:stretch;
   gap:10px;
-  flex-wrap:wrap;
   margin-left:auto;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -250,10 +250,13 @@ p{ margin:8px 0 }
 /* =========================
    Formularios / Inputs
    ========================= */
-.row{ display:flex; align-items:center; gap:var(--gap); flex-wrap:wrap }
+.row{ display:flex; align-items:center; gap:var(--gap); flex-wrap:wrap; width:100%; }
 .small-row{ gap:6px }
 .field{ display:flex; flex-direction:column; gap:6px; }
 .field.small-field{ flex:0 0 auto; min-width:220px; }
+
+#dropZone .row .field{ flex:1 1 0; min-width:min(260px,100%); }
+#dropZone .row .field input{ width:100%; }
 
 textarea, input, select{
   appearance:none; -webkit-appearance:none; -moz-appearance:none;
@@ -365,6 +368,13 @@ body[data-theme="light"] .btn{ color:#0a223d }
   background: linear-gradient(90deg, var(--danger), #f43f5e);
   color:#3b0a14;
 }
+.btn.yellow{
+  background: linear-gradient(90deg, #facc15, #eab308);
+  color:#3b2500;
+  box-shadow: 0 10px 24px rgba(250, 204, 21, .3), 0 0 0 1px rgba(255,255,255,.08) inset;
+}
+
+#clearBtn{ margin-left:auto; }
 
 /* =========================
    Switch
@@ -598,13 +608,15 @@ body[data-theme="light"] .btn{ color:#0a223d }
    ========================= */
 .footer{ text-align:center; margin-top:auto; color:var(--text-2); padding:12px 0 16px; }
 .footer .sig{
-  font-family:'Orbitron', ui-sans-serif;
-  font-size:clamp(10px,1.05vw,12px);
-  letter-spacing:1.4px; text-transform:uppercase;
-  background:linear-gradient(90deg, #7fd3ff, #8ad1ff);
-  -webkit-background-clip:text; background-clip:text;
-  color:transparent; opacity:.95;
+  font-family:'Space Grotesk', 'Orbitron', ui-sans-serif;
+  font-weight:700;
+  font-size:clamp(11px,1.25vw,14px);
+  letter-spacing:1.2px;
+  text-transform:uppercase;
+  color:var(--text-1);
+  text-shadow:0 0 18px rgba(14,165,233,.28);
 }
+.footer .sig strong{ font-weight:800; }
 .links{ display:flex; gap:8px; justify-content:center; align-items:center; flex-wrap:wrap; }
 .links .muted{ opacity:.9 }
 .dot{ opacity:.55 }
@@ -638,6 +650,7 @@ body[data-theme="light"] .btn{ color:#0a223d }
     align-items:stretch;
     gap:10px;
   }
+  #clearBtn{ margin-left:0; }
   .row.actions.one-line .chip{
     align-self:stretch;
     display:flex;

--- a/styles.css
+++ b/styles.css
@@ -207,7 +207,20 @@ body[data-theme="light"] .hero h1{
 .span-7{ grid-column:span 7 }
 .span-5{ grid-column:span 5 }
 .span-6{ grid-column:span 6 }
-@media (max-width: 960px){ .span-7, .span-6, .span-5, .span-12{ grid-column:1/-1 } }
+@media (max-width: 960px){
+  .span-7,
+  .span-6,
+  .span-5,
+  .span-12{ grid-column:1/-1; }
+
+  .graph-top{
+    flex-direction:column;
+    align-items:stretch;
+    gap:var(--gap);
+  }
+
+  .graph-controls{ width:100%; }
+}
 
 .card{
   position:relative; background: linear-gradient(180deg, var(--glass), var(--glass-2));
@@ -608,9 +621,101 @@ body[data-theme="light"] .btn{ color:#0a223d }
    Responsive
    ========================= */
 @media (max-width:720px){
-  .preview{ height:42vh }
-  .btn{ padding:10px 12px }
-  textarea{ min-height:160px }
+  .preview{ height:42vh; }
+  .btn{ padding:10px 12px; }
+  textarea{ min-height:160px; }
+  .wrap{ padding:clamp(16px,5vw,22px) clamp(12px,5vw,18px) clamp(48px,8vh,72px); }
+  .hero{ margin-bottom:clamp(14px,4vh,24px); }
+  .row{ gap:12px; }
+  .field.small-field{ flex:1 1 100%; min-width:0; }
+  .topbar .row{ flex-direction:column; align-items:stretch; gap:12px; }
+  .topbar .row .actions.one-line{
+    margin-left:0;
+    justify-content:flex-start;
+  }
+  .row.actions.one-line{
+    flex-direction:column;
+    align-items:stretch;
+    gap:10px;
+  }
+  .row.actions.one-line .chip{
+    align-self:stretch;
+    display:flex;
+    justify-content:center;
+    gap:6px;
+    text-align:center;
+  }
+  .row.actions.one-line .btn{
+    width:100%;
+    min-height:44px;
+  }
+  .row.actions.one-line label.switch{
+    width:100%;
+    justify-content:space-between;
+    padding:12px 14px;
+    border:1px solid var(--border);
+    border-radius:var(--radius-xs);
+    background:var(--surface-0);
+  }
+  .row.actions.one-line label.switch .lbl{ margin-left:auto; }
+  .preview-head .row.small-row{ width:100%; gap:10px; }
+  .preview-head .row.small-row > *{ flex:1 1 100%; }
+  .preview-head .row.small-row label.switch{
+    justify-content:space-between;
+    padding:10px 12px;
+    border:1px solid var(--border);
+    border-radius:var(--radius-xs);
+    background:var(--surface-0);
+  }
+  .preview-head .row.small-row label.switch .lbl{ margin-left:auto; }
+  .graph-controls{
+    flex-direction:column;
+    align-items:stretch;
+    gap:12px;
+  }
+  .graph-layout-group{
+    width:100%;
+    flex-direction:column;
+    align-items:stretch;
+    gap:6px;
+  }
+  .graph-layout-group .graph-label{
+    display:block;
+    width:100%;
+  }
+  .graph-select{
+    width:100%;
+    min-width:0;
+    min-height:44px;
+  }
+  .graph-button-group{
+    width:100%;
+    margin-left:0;
+    justify-content:stretch;
+    gap:10px;
+  }
+  .graph-button-group .graph-refresh,
+  .graph-button-group .graph-fullscreen-btn{
+    width:100%;
+    min-height:44px;
+  }
+  .graph-button-group .graph-fullscreen-btn{ justify-content:center; }
+  #graph{ height:clamp(340px, 60vh, 560px); }
+  .chat-input{ flex-direction:column; gap:10px; }
+  .chat-input button{ width:100%; }
+  .res-head{ flex-direction:column; align-items:stretch; gap:10px; }
+  .res-head .btn{ width:100%; }
+  .session-toast{
+    left:50%;
+    right:auto;
+    top:auto;
+    bottom:clamp(16px, 6vh, 32px);
+    width:min(92vw, 380px);
+    max-width:min(92vw, 380px);
+    text-align:center;
+    transform:translate(-50%, 12px);
+  }
+  .session-toast.is-visible{ transform:translate(-50%, 0); }
 }
 @media (max-width:420px){
   .badge{ display:none }
@@ -1224,22 +1329,55 @@ body[data-theme="light"] .table thead th{
 .chat-log p.bot{ color:var(--text-1); }
 .chat-input{ display:flex; gap:8px; }
 .chat-input input{ flex:1; }
-#graph{ height:400px; }
+
+#graphPanel{
+  display:flex;
+  flex-direction:column;
+  gap:var(--gap);
+}
+
+#graph{
+  position:relative;
+  width:100%;
+  height:clamp(320px, 38vh, 460px);
+  border:1px solid var(--border);
+  border-radius:var(--radius-sm);
+  background:var(--surface-0);
+  overflow:hidden;
+  flex:0 0 auto;
+}
 
 .graph-top{
   display:flex;
   align-items:flex-start;
   justify-content:space-between;
   gap:var(--gap);
-  margin-bottom:var(--gap);
+  margin-bottom:0;
   flex-wrap:wrap;
 }
 
-.graph-actions{
+.graph-controls{
+  flex:1 1 auto;
+  display:flex;
+  align-items:center;
+  gap:14px;
+  flex-wrap:wrap;
+  min-width:0;
+}
+
+.graph-layout-group{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  flex-wrap:wrap;
+}
+
+.graph-button-group{
   display:flex;
   align-items:center;
   gap:10px;
   flex-wrap:wrap;
+  margin-left:auto;
 }
 
 .graph-label{
@@ -1345,7 +1483,8 @@ body[data-theme="light"] .graph-refresh{ color:#0a223d; }
 
 #graphPanel.fullscreen #graph{
   flex:1 1 auto;
-  height:auto;
+  height:100%;
+  min-height:clamp(480px, 70vh, 820px);
 }
 
 #graphPanel.fullscreen .graph-fullscreen-btn{
@@ -1366,7 +1505,7 @@ body[data-theme="light"] .graph-refresh{ color:#0a223d; }
   box-shadow:0 0 0 3px rgba(239,68,68,.35);
 }
 
-.color-controls{ display:none; gap:8px; flex-wrap:wrap; margin-bottom:var(--gap); }
+.color-controls{ display:none; gap:8px; flex-wrap:wrap; margin-bottom:0; }
 #graphPanel.fullscreen .color-controls{ display:flex; }
 .color-item{ display:flex; align-items:center; gap:4px; }
 .color-item input{ width:40px; height:24px; padding:0; border:none; background:transparent; }
@@ -1505,14 +1644,18 @@ body[data-theme="light"] .session-modal-icon{
 .login-screen{
   position:fixed;
   inset:0;
-  display:grid;
-  place-items:center;
+  display:flex;
+  align-items:center;
+  justify-content:center;
   padding:clamp(24px, 6vw, 60px);
   background:
     radial-gradient(70vw 60vh at -15% -15%, rgba(4,26,64,.72), transparent 65%),
     radial-gradient(65vw 60vh at 125% 10%, rgba(2,24,51,.68), transparent 60%),
     linear-gradient(140deg, var(--bg1), var(--bg2));
   z-index:1000;
+  min-height:100vh;
+  width:100%;
+  overflow:auto;
 }
 
 .login-card{
@@ -1636,4 +1779,29 @@ body[data-theme="light"] .session-modal-icon{
   font-weight:700;
   display:none;
 }
+
+.admin-access-link{
+  margin:6px 0 0;
+  align-self:center;
+  background:none;
+  border:0;
+  color:var(--pri);
+  font-weight:700;
+  cursor:pointer;
+  padding:0;
+  font-size:.95rem;
+  text-decoration:none;
+  transition:color .15s ease;
+}
+
+.admin-access-link:hover,
+.admin-access-link:focus-visible{ color:var(--sec); }
+
+.admin-access-link:focus-visible{
+  outline:2px solid rgba(14,165,233,.45);
+  outline-offset:3px;
+  border-radius:6px;
+}
+
+[data-theme="light"] .admin-access-link{ color:#0369a1; }
 


### PR DESCRIPTION
## Summary
- split the graph header controls into layout and button groups so the "Organizar" selector stays on the left while actions sit on the right
- adjust the responsive styles to stack the new control groups cleanly on phones and give the graph container an explicit height so it renders outside of fullscreen

## Testing
- Not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68c9f79c522083308daf20853d9ac328