### PR TITLE
Centra notificaciones de sesión en móvil

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1666,6 +1666,68 @@ body[data-theme="light"] .session-toast{
   height:48px;
 }
 
+@media (max-width: 520px){
+  .session-toast{
+    left:50%;
+    right:auto;
+    width:min(92vw, 360px);
+    max-width:calc(100vw - 24px);
+    transform:translate(-50%, -12px);
+    text-align:center;
+  }
+
+  .session-toast.is-visible{
+    transform:translate(-50%, 0);
+  }
+
+  .login-screen,
+  .session-modal{
+    padding:clamp(16px, 5vw, 24px);
+    align-items:center;
+    justify-content:center;
+  }
+
+  .login-card,
+  .session-modal-card{
+    width:min(100%, 340px);
+    border-radius:20px;
+    padding:clamp(22px, 6vw, 28px);
+    gap:14px;
+  }
+
+  .session-modal-card{
+    box-shadow:0 18px 40px rgba(2,6,23,.45);
+  }
+
+  .session-modal-icon{
+    width:66px;
+    height:66px;
+    font-size:26px;
+  }
+
+  .login-card h2,
+  .session-modal-card h3{
+    font-size:clamp(20px, 6.5vw, 26px);
+  }
+
+  .login-card .field span,
+  .buy-info,
+  .loading-msg,
+  .error-msg,
+  .admin-access-link,
+  .session-modal-card p{
+    font-size:clamp(.9rem, 3.6vw, 1rem);
+  }
+
+  #loginEmail,
+  #loginPassword,
+  .login-primary,
+  .login-buy,
+  #sessionModalClose{
+    height:46px;
+  }
+}
+
 html[data-theme="light"] .session-modal-card,
 body[data-theme="light"] .session-modal-card{
   background: linear-gradient(180deg, rgba(255,255,255,.97), rgba(241,245,249,.94));


### PR DESCRIPTION
## Summary
- centra los avisos de sesión en móviles y limita su ancho para evitar desbordes
- mantiene las tarjetas de inicio/cierre centradas y con sombras ajustadas en pantallas pequeñas

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca5638f8588330a5d79e9b91e5ebc1