### PR TITLE
Add registration flow and account summary panel

### DIFF
--- a/Panel Admin/app.js
+++ b/Panel Admin/app.js
@@ -418,16 +418,24 @@ qs('#q')?.addEventListener('input', ()=>{
 });
 qs('#q')?.addEventListener('keydown', (e)=>{ if(e.key==='Enter'){ page=1; loadUsers(); }});
 qs('#btnSearch')?.addEventListener('click', ()=>{ page=1; loadUsers(); });
-btnGoClient?.addEventListener('click', ()=>{
+function navigateToClientApp(event){
+  if(event){
+    if(typeof event.preventDefault === 'function') event.preventDefault();
+    if(typeof event.stopPropagation === 'function') event.stopPropagation();
+  }
+  sessionLoading(true, 'Conectando con WF-TOOLS…');
   try{
-    const newTab = window.open(CLIENT_APP_URL, '_blank', 'noopener');
-    if(!newTab){
-      window.location.href = CLIENT_APP_URL;
+    if(window.self !== window.top && window.parent && typeof window.parent.showFrame === 'function'){
+      window.parent.showFrame('wfFrame');
+      setTimeout(()=> sessionLoading(false), 600);
+      return;
     }
   } catch(_err){
-    window.location.href = CLIENT_APP_URL;
+    /* ignorado */
   }
-});
+  window.location.href = CLIENT_APP_URL;
+}
+btnGoClient?.addEventListener('click', navigateToClientApp);
 qs('#btnReload')?.addEventListener('click', ()=> loadUsers());
 qs('#prev')?.addEventListener('click', ()=>{ if(page>1){ page--; loadUsers(); }});
 qs('#next')?.addEventListener('click', ()=>{ page++; loadUsers(); });

--- a/Panel Admin/app.js
+++ b/Panel Admin/app.js
@@ -426,14 +426,14 @@ function navigateToClientApp(event){
   sessionLoading(true, 'Conectando con WF-TOOLS…');
   try{
     if(window.self !== window.top && window.parent && typeof window.parent.showFrame === 'function'){
-      window.parent.showFrame('wfFrame');
-      setTimeout(()=> sessionLoading(false), 600);
+      window.parent.showFrame('wfFrame', { reload:true });
+      setTimeout(()=> sessionLoading(false), 900);
       return;
     }
   } catch(_err){
     /* ignorado */
   }
-  window.location.href = CLIENT_APP_URL;
+  window.location.replace(CLIENT_APP_URL);
 }
 btnGoClient?.addEventListener('click', navigateToClientApp);
 qs('#btnReload')?.addEventListener('click', ()=> loadUsers());

--- a/Panel Admin/app.js
+++ b/Panel Admin/app.js
@@ -16,6 +16,7 @@ const FUNCTIONS_BASE = SUPABASE_URL.replace('.supabase.co', '.functions.supabase
 
 // ✅ Ruta del LOGO (PNG) para el UI
 const LOGO_URL = './WF TOOLS.png';
+const CLIENT_APP_URL = '../WF-TOOLS/index.html';
 
 const ENDPOINTS = {
   list: 'admin-list',
@@ -61,6 +62,7 @@ const accountTotalCreditsDetailEl = qs('#accountTotalCreditsDetail');
 const accountActiveCountEl = qs('#accountActiveCount');
 const accountAlertsEl = qs('#accountAlerts');
 const accountStatusTag = qs('#accountStatusTag');
+const btnGoClient = qs('#btnGoClient');
 
 // Inyectar logo en login y header (con seguridad si no existen)
 const loginLogoEl = qs('#loginLogo');
@@ -416,6 +418,16 @@ qs('#q')?.addEventListener('input', ()=>{
 });
 qs('#q')?.addEventListener('keydown', (e)=>{ if(e.key==='Enter'){ page=1; loadUsers(); }});
 qs('#btnSearch')?.addEventListener('click', ()=>{ page=1; loadUsers(); });
+btnGoClient?.addEventListener('click', ()=>{
+  try{
+    const newTab = window.open(CLIENT_APP_URL, '_blank', 'noopener');
+    if(!newTab){
+      window.location.href = CLIENT_APP_URL;
+    }
+  } catch(_err){
+    window.location.href = CLIENT_APP_URL;
+  }
+});
 qs('#btnReload')?.addEventListener('click', ()=> loadUsers());
 qs('#prev')?.addEventListener('click', ()=>{ if(page>1){ page--; loadUsers(); }});
 qs('#next')?.addEventListener('click', ()=>{ page++; loadUsers(); });

--- a/Panel Admin/index.html
+++ b/Panel Admin/index.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="styles.css" />
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="app.js" defer></script>
 </head>
 <body>
@@ -74,69 +75,7 @@
         <button id="btnRecover" class="btn btn-ghost">Olvidé mi contraseña</button>
         <span id="loginHint" class="hint">Zona de administradores WF-TOOLS</span>
       </div>
-      <button id="btnShowRegister" class="btn btn-ghost btn-alt" type="button">Registrarme</button>
       <div id="loginError" class="error" style="display:none"></div>
-    </section>
-
-    <!-- REGISTER VIEW -->
-    <section id="registerView" class="card view" data-display="flex" style="display:none">
-      <div class="brand">
-        <div class="logo">
-          <img id="registerLogo" alt="WF TOOLS logo" />
-        </div>
-        <h1>Crear cuenta WF-TOOLS</h1>
-        <div class="muted">Completa el formulario para recibir tu usuario de acceso</div>
-      </div>
-      <form id="registerForm" class="register-form">
-        <div class="field">
-          <label for="reg_name">Nombre completo</label>
-          <input id="reg_name" class="input" type="text" placeholder="Tu nombre" autocomplete="name" required />
-        </div>
-        <div class="field">
-          <label for="reg_email">Correo electrónico</label>
-          <input
-            id="reg_email"
-            class="input"
-            type="email"
-            placeholder="correo@ejemplo.com"
-            autocomplete="email"
-            required
-          />
-        </div>
-        <div class="field">
-          <label for="reg_phone">Número de teléfono</label>
-          <input
-            id="reg_phone"
-            class="input"
-            type="tel"
-            placeholder="300 000 0000"
-            autocomplete="tel"
-            required
-          />
-        </div>
-        <div class="field">
-          <label for="reg_password">Contraseña</label>
-          <input
-            id="reg_password"
-            class="input"
-            type="password"
-            placeholder="Mínimo 8 caracteres"
-            autocomplete="new-password"
-            required
-          />
-        </div>
-        <div id="registerError" class="error" style="display:none"></div>
-        <div id="registerSuccess" class="register-success" style="display:none">
-          <div class="register-success__title">¡Registro exitoso!</div>
-          <p>Tu usuario WF TOOLS es <strong id="registerUsername">—</strong> y el correo generado es <strong id="registerUserEmail">—</strong>.</p>
-          <p class="muted">Utiliza estos datos junto con tu contraseña para ingresar a WF TOOLS.</p>
-        </div>
-        <button id="btnRegister" class="btn btn-primary" type="submit">
-          <span class="btn-text">Crear cuenta</span>
-          <span class="btn-spinner" style="display:none">⏳ Registrando…</span>
-        </button>
-      </form>
-      <button id="btnBackLogin" class="btn btn-ghost btn-alt" type="button">Ya tengo una cuenta</button>
     </section>
 
     <!-- ADMIN VIEW -->
@@ -181,9 +120,7 @@
           </div>
           <div class="account-card__body">
             <div class="account-user">
-              <div class="account-user__avatar">
-                <img id="accountAvatar" alt="Avatar WF TOOLS" />
-              </div>
+              <div class="account-user__icon" aria-hidden="true">🛡️</div>
               <div class="account-user__info">
                 <div id="accountUserName" class="account-user__name">—</div>
                 <div id="accountUserEmail" class="account-user__email">—</div>
@@ -191,8 +128,9 @@
             </div>
             <div class="account-metrics">
               <div class="account-metric">
-                <span class="label">Créditos totales</span>
-                <strong id="accountTotalCredits">0</strong>
+                <span class="label">Valor créditos (COP)</span>
+                <strong id="accountTotalCredits">$0</strong>
+                <span id="accountTotalCreditsDetail" class="sub">0 créditos clientes</span>
               </div>
               <div class="account-metric">
                 <span class="label">Cuentas activas</span>
@@ -202,6 +140,16 @@
                 <span class="label">Alertas</span>
                 <strong id="accountAlerts">0</strong>
               </div>
+            </div>
+            <div class="account-actions">
+              <button id="btnReviewAlerts" class="btn btn-ghost btn-sm account-action">
+                <span class="icon" aria-hidden="true">⚠️</span>
+                <span>Revisar alertas</span>
+              </button>
+              <button id="btnDownloadReport" class="btn btn-primary btn-sm account-action">
+                <span class="icon" aria-hidden="true">📊</span>
+                <span>Generar reporte XLSX</span>
+              </button>
             </div>
           </div>
         </div>

--- a/Panel Admin/index.html
+++ b/Panel Admin/index.html
@@ -74,7 +74,69 @@
         <button id="btnRecover" class="btn btn-ghost">Olvidé mi contraseña</button>
         <span id="loginHint" class="hint">Zona de administradores WF-TOOLS</span>
       </div>
+      <button id="btnShowRegister" class="btn btn-ghost btn-alt" type="button">Registrarme</button>
       <div id="loginError" class="error" style="display:none"></div>
+    </section>
+
+    <!-- REGISTER VIEW -->
+    <section id="registerView" class="card view" data-display="flex" style="display:none">
+      <div class="brand">
+        <div class="logo">
+          <img id="registerLogo" alt="WF TOOLS logo" />
+        </div>
+        <h1>Crear cuenta WF-TOOLS</h1>
+        <div class="muted">Completa el formulario para recibir tu usuario de acceso</div>
+      </div>
+      <form id="registerForm" class="register-form">
+        <div class="field">
+          <label for="reg_name">Nombre completo</label>
+          <input id="reg_name" class="input" type="text" placeholder="Tu nombre" autocomplete="name" required />
+        </div>
+        <div class="field">
+          <label for="reg_email">Correo electrónico</label>
+          <input
+            id="reg_email"
+            class="input"
+            type="email"
+            placeholder="correo@ejemplo.com"
+            autocomplete="email"
+            required
+          />
+        </div>
+        <div class="field">
+          <label for="reg_phone">Número de teléfono</label>
+          <input
+            id="reg_phone"
+            class="input"
+            type="tel"
+            placeholder="300 000 0000"
+            autocomplete="tel"
+            required
+          />
+        </div>
+        <div class="field">
+          <label for="reg_password">Contraseña</label>
+          <input
+            id="reg_password"
+            class="input"
+            type="password"
+            placeholder="Mínimo 8 caracteres"
+            autocomplete="new-password"
+            required
+          />
+        </div>
+        <div id="registerError" class="error" style="display:none"></div>
+        <div id="registerSuccess" class="register-success" style="display:none">
+          <div class="register-success__title">¡Registro exitoso!</div>
+          <p>Tu usuario WF TOOLS es <strong id="registerUsername">—</strong> y el correo generado es <strong id="registerUserEmail">—</strong>.</p>
+          <p class="muted">Utiliza estos datos junto con tu contraseña para ingresar a WF TOOLS.</p>
+        </div>
+        <button id="btnRegister" class="btn btn-primary" type="submit">
+          <span class="btn-text">Crear cuenta</span>
+          <span class="btn-spinner" style="display:none">⏳ Registrando…</span>
+        </button>
+      </form>
+      <button id="btnBackLogin" class="btn btn-ghost btn-alt" type="button">Ya tengo una cuenta</button>
     </section>
 
     <!-- ADMIN VIEW -->
@@ -107,6 +169,43 @@
           <button id="btnLogout" class="btn btn-logout"><span class="icon">✖️</span><span>Salir</span></button>
         </div>
       </header>
+
+      <section id="accountPanel" class="account-panel" style="display:none">
+        <div class="account-card">
+          <div class="account-card__head">
+            <div>
+              <h3>Estado de cuenta</h3>
+              <p class="muted">Resumen del administrador conectado</p>
+            </div>
+            <span class="account-card__tag" id="accountStatusTag">Activo</span>
+          </div>
+          <div class="account-card__body">
+            <div class="account-user">
+              <div class="account-user__avatar">
+                <img id="accountAvatar" alt="Avatar WF TOOLS" />
+              </div>
+              <div class="account-user__info">
+                <div id="accountUserName" class="account-user__name">—</div>
+                <div id="accountUserEmail" class="account-user__email">—</div>
+              </div>
+            </div>
+            <div class="account-metrics">
+              <div class="account-metric">
+                <span class="label">Créditos totales</span>
+                <strong id="accountTotalCredits">0</strong>
+              </div>
+              <div class="account-metric">
+                <span class="label">Cuentas activas</span>
+                <strong id="accountActiveCount">0</strong>
+              </div>
+              <div class="account-metric">
+                <span class="label">Alertas</span>
+                <strong id="accountAlerts">0</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <div class="panel">
         <div id="creditSummary" class="stats" style="display:none"></div>

--- a/Panel Admin/index.html
+++ b/Panel Admin/index.html
@@ -104,6 +104,7 @@
             <span id="cuEmail" class="cu-email">—</span>
           </div>
 
+          <button id="btnGoClient" class="btn btn-admin-portal"><span class="icon" aria-hidden="true">🛠️</span><span>Abrir WF-TOOLS</span></button>
           <button id="btnReload" class="btn btn-reload"><span class="icon">🔄</span><span>Recargar</span></button>
           <button id="btnLogout" class="btn btn-logout"><span class="icon">✖️</span><span>Salir</span></button>
         </div>

--- a/Panel Admin/styles.css
+++ b/Panel Admin/styles.css
@@ -87,16 +87,6 @@ a{color:var(--brand)}
 .btn-sm{padding:8px 10px; font-size:.86rem; border-radius:12px}
 .row{display:flex; gap:10px; align-items:center; flex-wrap:wrap}
 
-#registerView{
-  max-width:560px; padding:32px; position:relative; text-align:center;
-  display:flex; flex-direction:column; align-items:center; gap:12px
-}
-#registerView .register-form{width:100%; display:grid; gap:6px}
-#registerView .btn{width:100%}
-.register-success{border:1px solid rgba(34,197,94,.45); background:rgba(34,197,94,.12); color:#bbf7d0; padding:14px 16px; border-radius:14px; text-align:left; margin:6px 0 4px; box-shadow:0 8px 16px rgba(34,197,94,.12)}
-.register-success__title{font-weight:700; font-size:1rem; margin-bottom:4px; color:#22c55e}
-.register-success strong{color:#fef9c3}
-
 .hint{margin-top:8px; color:var(--muted); font-size:.86rem}
 .error{color:var(--danger); font-size:.9rem; margin-top:6px}
 
@@ -174,20 +164,24 @@ a{color:var(--brand)}
 .account-card__tag.danger{background:rgba(239,68,68,.18); color:#fecaca; border-color:rgba(239,68,68,.45)}
 .account-card__body{display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between}
 .account-user{display:flex; align-items:center; gap:12px; min-width:220px}
-.account-user__avatar{width:64px; height:64px; border-radius:18px; overflow:hidden; border:1px solid var(--border); background:rgba(14,165,233,.1); display:grid; place-items:center}
-.account-user__avatar img{width:100%; height:100%; object-fit:contain}
+.account-user__icon{width:64px; height:64px; border-radius:18px; border:1px solid var(--border); background:rgba(59,130,246,.18); display:grid; place-items:center; font-size:2rem}
 .account-user__info{display:grid; gap:4px}
 .account-user__name{font-size:1.05rem; font-weight:700}
 .account-user__email{color:#8fbfe6; font-size:.9rem; word-break:break-all}
 .account-metrics{display:flex; gap:18px; flex-wrap:wrap; justify-content:flex-end}
-.account-metric{min-width:120px; background:rgba(15,18,26,.85); border:1px solid var(--border); border-radius:14px; padding:14px 16px; display:grid; gap:6px; text-align:left}
+.account-metric{min-width:160px; background:rgba(15,18,26,.85); border:1px solid var(--border); border-radius:14px; padding:14px 16px; display:grid; gap:6px; text-align:left}
 .account-metric .label{font-size:.8rem; color:var(--muted)}
 .account-metric strong{font-size:1.1rem}
+.account-metric .sub{font-size:.78rem; color:#8fbfe6}
+.account-actions{display:flex; gap:12px; flex-wrap:wrap; margin-top:16px; width:100%; justify-content:flex-end}
+.account-action{display:inline-flex; align-items:center; gap:8px; font-weight:600}
+.account-action .icon{font-size:1.1rem}
 
 @media (max-width:768px){
   .account-card__body{flex-direction:column; align-items:flex-start}
   .account-metrics{width:100%; justify-content:flex-start}
   .account-metric{width:100%}
+  .account-actions{justify-content:flex-start}
 }
 .stats{display:flex; gap:16px; flex-wrap:wrap; margin-bottom:18px; justify-content:center}
 .stat-card{flex:1 1 280px; min-width:260px; display:flex; align-items:center; gap:12px; background:var(--card); border:1px solid var(--border); border-radius:14px; padding:18px; box-shadow:var(--shadow)}
@@ -247,6 +241,15 @@ tbody tr td{border-top:1px solid rgba(255,255,255,.03); border-bottom:1px solid 
 .credit-high{background:rgba(34,197,94,.15); color:#bbf7d0; border-color:rgba(34,197,94,.35)}
 .credit-high .dot{background:var(--ok)}
 .credit-warning{margin-top:6px; padding:8px 10px; border-radius:12px; font-size:.78rem; background:rgba(239,68,68,.1); border:1px solid rgba(239,68,68,.3); color:#fecaca}
+.credit-warning.highlight-alert{box-shadow:0 0 0 3px rgba(239,68,68,.35); animation:pulse-alert 1.2s ease-in-out 0s 2}
+.table-wrap tr.row-alert{position:relative}
+.table-wrap tr.row-alert::after{content:''; position:absolute; inset:0; border-left:3px solid rgba(239,68,68,.6); border-radius:6px; pointer-events:none}
+.card-row.row-alert{border:1px solid rgba(239,68,68,.35)}
+
+@keyframes pulse-alert{
+  0%,100%{transform:scale(1);}
+  50%{transform:scale(1.02);}
+}
 .pager{display:flex; gap:10px; align-items:center; justify-content:flex-end; margin-top:10px}
 
 .view{opacity:0; transform:translateY(14px); transition:opacity .28s ease, transform .28s ease; pointer-events:none}

--- a/Panel Admin/styles.css
+++ b/Panel Admin/styles.css
@@ -51,6 +51,7 @@ a{color:var(--brand)}
 }
 #loginView .btn{width:100%}
 #loginView .login-actions{width:100%; display:flex; flex-direction:column; gap:10px; align-items:stretch; text-align:center}
+.btn-alt{width:100%; margin-top:8px}
 .brand{display:flex; flex-direction:column; align-items:center; gap:10px; margin-bottom:18px}
 .brand .logo{
   width:140px; height:140px; display:grid; place-items:center; border-radius:18px;
@@ -85,6 +86,16 @@ a{color:var(--brand)}
 .btn-ghost{background:#0b0f15; color:#fff; border:1px solid var(--border)}
 .btn-sm{padding:8px 10px; font-size:.86rem; border-radius:12px}
 .row{display:flex; gap:10px; align-items:center; flex-wrap:wrap}
+
+#registerView{
+  max-width:560px; padding:32px; position:relative; text-align:center;
+  display:flex; flex-direction:column; align-items:center; gap:12px
+}
+#registerView .register-form{width:100%; display:grid; gap:6px}
+#registerView .btn{width:100%}
+.register-success{border:1px solid rgba(34,197,94,.45); background:rgba(34,197,94,.12); color:#bbf7d0; padding:14px 16px; border-radius:14px; text-align:left; margin:6px 0 4px; box-shadow:0 8px 16px rgba(34,197,94,.12)}
+.register-success__title{font-weight:700; font-size:1rem; margin-bottom:4px; color:#22c55e}
+.register-success strong{color:#fef9c3}
 
 .hint{margin-top:8px; color:var(--muted); font-size:.86rem}
 .error{color:var(--danger); font-size:.9rem; margin-top:6px}
@@ -153,6 +164,31 @@ a{color:var(--brand)}
 }
 
 .panel{padding:16px; position:relative; overflow-x:hidden}
+.account-panel{padding:20px 22px 6px; border-bottom:1px solid var(--border)}
+.account-card{display:grid; gap:18px; background:var(--card); border:1px solid var(--border); border-radius:16px; padding:20px; box-shadow:var(--shadow)}
+.account-card__head{display:flex; align-items:flex-start; justify-content:space-between; gap:16px}
+.account-card__head h3{margin:0; font-size:1.1rem}
+.account-card__head .muted{margin-top:4px; font-size:.85rem}
+.account-card__tag{border-radius:999px; padding:6px 12px; background:rgba(34,197,94,.15); color:#86efac; font-weight:700; font-size:.8rem; border:1px solid rgba(34,197,94,.35)}
+.account-card__tag.warn{background:rgba(245,158,11,.18); color:#facc15; border-color:rgba(245,158,11,.4)}
+.account-card__tag.danger{background:rgba(239,68,68,.18); color:#fecaca; border-color:rgba(239,68,68,.45)}
+.account-card__body{display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between}
+.account-user{display:flex; align-items:center; gap:12px; min-width:220px}
+.account-user__avatar{width:64px; height:64px; border-radius:18px; overflow:hidden; border:1px solid var(--border); background:rgba(14,165,233,.1); display:grid; place-items:center}
+.account-user__avatar img{width:100%; height:100%; object-fit:contain}
+.account-user__info{display:grid; gap:4px}
+.account-user__name{font-size:1.05rem; font-weight:700}
+.account-user__email{color:#8fbfe6; font-size:.9rem; word-break:break-all}
+.account-metrics{display:flex; gap:18px; flex-wrap:wrap; justify-content:flex-end}
+.account-metric{min-width:120px; background:rgba(15,18,26,.85); border:1px solid var(--border); border-radius:14px; padding:14px 16px; display:grid; gap:6px; text-align:left}
+.account-metric .label{font-size:.8rem; color:var(--muted)}
+.account-metric strong{font-size:1.1rem}
+
+@media (max-width:768px){
+  .account-card__body{flex-direction:column; align-items:flex-start}
+  .account-metrics{width:100%; justify-content:flex-start}
+  .account-metric{width:100%}
+}
 .stats{display:flex; gap:16px; flex-wrap:wrap; margin-bottom:18px; justify-content:center}
 .stat-card{flex:1 1 280px; min-width:260px; display:flex; align-items:center; gap:12px; background:var(--card); border:1px solid var(--border); border-radius:14px; padding:18px; box-shadow:var(--shadow)}
 .stat-icon{width:42px; height:42px; border-radius:12px; display:grid; place-items:center; font-size:1.3rem; background:rgba(14,165,233,.14); color:#38bdf8}

--- a/Panel Admin/styles.css
+++ b/Panel Admin/styles.css
@@ -124,6 +124,21 @@ a{color:var(--brand)}
 .toolbar .btn{width:100%; justify-content:center; display:inline-flex; align-items:center; gap:8px; font-weight:600}
 .toolbar .icon{font-size:1rem}
 .toolbar .btn-search{background:rgba(14,165,233,.16); color:#38bdf8; border:1px solid rgba(14,165,233,.35)}
+.toolbar .btn-admin-portal{
+  background:linear-gradient(135deg, rgba(14,165,233,.24), rgba(56,189,248,.38));
+  color:#e0f2fe;
+  border:1px solid rgba(56,189,248,.45);
+  box-shadow:0 14px 32px rgba(14,165,233,.28);
+  transition:transform .12s ease, box-shadow .2s ease, background .2s ease;
+}
+.toolbar .btn-admin-portal:hover{
+  transform:translateY(-1px);
+  box-shadow:0 18px 38px rgba(14,165,233,.32);
+}
+.toolbar .btn-admin-portal:focus-visible{
+  outline:3px solid rgba(56,189,248,.45);
+  outline-offset:3px;
+}
 .toolbar .btn-reload{background:rgba(59,130,246,.15); color:#93c5fd; border:1px solid rgba(59,130,246,.35)}
 .toolbar .btn-logout{background:rgba(239,68,68,.18); color:#fca5a5; border:1px solid rgba(239,68,68,.45)}
 

--- a/WF-TOOLS/index.html
+++ b/WF-TOOLS/index.html
@@ -162,6 +162,16 @@
         <div class="row actions one-line">
           <div class="chip" id="planChip" style="display:none;">Plan: <span id="planName">-</span></div>
           <div class="chip" id="creditsChip" style="display:none;">Créditos: <span id="creditCount">0</span></div>
+          <button
+            id="adminPanelBtnInline"
+            class="btn admin-portal-btn admin-portal-inline"
+            type="button"
+            aria-hidden="true"
+            hidden
+          >
+            <span aria-hidden="true" class="icon">🛡️</span>
+            <span>Abrir panel administrador</span>
+          </button>
           <button id="logoutBtn" class="btn danger" style="display:none;">Cerrar sesión</button>
         </div>
       </div>

--- a/WF-TOOLS/index.html
+++ b/WF-TOOLS/index.html
@@ -25,38 +25,82 @@
   </div>
   <!-- Pantalla de inicio de sesión -->
   <div id="loginScreen" class="login-screen">
-    <form id="loginForm" class="login-card">
-      <h2 class="title-heading">
-         <img class="title-logo" src="WF%20TOOLS.png" alt="WF TOOLS">
-        <span class="title-text">Bienvenido a WF-TOOLS</span>
-          </h2>
-      <label class="field">
-        <span>Correo/usuario</span>
-        <input type="email" id="loginEmail" placeholder="usuario@correo.com" autocomplete="username" autofocus required />
-      </label>
-      <label class="field password-field">
-        <span>Contraseña</span>
-        <div class="input-affix">
-          <input type="password" id="loginPassword" placeholder="Contraseña" autocomplete="current-password" required />
-          <button type="button" id="loginTogglePassword" class="input-affix__action" aria-label="Mostrar contraseña" aria-pressed="false">Mostrar</button>
-        </div>
-      </label>
-      <div class="login-extras">
-        <label class="remember-option" for="loginRemember">
-          <input type="checkbox" id="loginRemember" />
-          <span class="remember-option__decor" aria-hidden="true"></span>
-          <span class="remember-option__label">Recordar usuario</span>
+    <div class="login-card-stack">
+      <form id="loginForm" class="login-card" data-view="login">
+        <h2 class="title-heading">
+          <img class="title-logo" src="WF%20TOOLS.png" alt="WF TOOLS">
+          <span class="title-text">Bienvenido a WF-TOOLS</span>
+        </h2>
+        <label class="field">
+          <span>Correo/usuario</span>
+          <input type="email" id="loginEmail" placeholder="usuario@correo.com" autocomplete="username" autofocus required />
         </label>
-      </div>
-      <button id="loginBtn" class="btn login-primary">Entrar</button>
-      <!-- Eliminamos el botón de compra y el texto de WhatsApp.  En su lugar mostramos
-           un mensaje que indica al usuario que utilice el botón flotante de recarga
-           ubicado en la esquina inferior izquierda. -->
-      <p class="buy-info">Para recargar tu cuenta, utiliza el botón en la esquina inferior izquierda.</p>
-      <button id="adminAccessBtn" type="button" class="admin-access-link">Ingreso administrado🔒</button>
-      <p id="loginLoading" class="loading-msg">Iniciando sesión...</p>
-      <p id="loginError" class="error-msg"></p>
-    </form>
+        <label class="field password-field">
+          <span>Contraseña</span>
+          <div class="input-affix">
+            <input type="password" id="loginPassword" placeholder="Contraseña" autocomplete="current-password" required />
+            <button type="button" id="loginTogglePassword" class="input-affix__action" aria-label="Mostrar contraseña" aria-pressed="false">Mostrar</button>
+          </div>
+        </label>
+        <div class="login-extras">
+          <label class="remember-option" for="loginRemember">
+            <input type="checkbox" id="loginRemember" />
+            <span class="remember-option__decor" aria-hidden="true"></span>
+            <span class="remember-option__label">Recordar usuario</span>
+          </label>
+        </div>
+        <button id="loginBtn" class="btn login-primary">Entrar</button>
+        <!-- Eliminamos el botón de compra y el texto de WhatsApp.  En su lugar mostramos
+             un mensaje que indica al usuario que utilice el botón flotante de recarga
+             ubicado en la esquina inferior izquierda. -->
+        <p class="buy-info">Para recargar tu cuenta, utiliza el botón en la esquina inferior izquierda.</p>
+        <div class="login-links">
+          <button type="button" id="showRegisterBtn" class="link-button">Registrarme</button>
+          <button id="adminAccessBtn" type="button" class="admin-access-link">Ingreso administrado🔒</button>
+        </div>
+        <p id="loginLoading" class="loading-msg">Iniciando sesión...</p>
+        <p id="loginError" class="error-msg"></p>
+      </form>
+
+      <form id="registerForm" class="login-card is-hidden" data-view="register" novalidate>
+        <h2 class="title-heading">
+          <img class="title-logo" src="WF%20TOOLS.png" alt="WF TOOLS">
+          <span class="title-text">Crea tu acceso</span>
+        </h2>
+        <p class="register-intro">Registra tus datos para generar tu usuario WF TOOLS. Recibirás un usuario automático con el formato <strong>clien.&lt;nombre&gt;@wftools.com</strong>.</p>
+        <label class="field">
+          <span>Nombre completo</span>
+          <input type="text" id="reg_name" placeholder="Ej. Maria Fernanda" autocomplete="name" required />
+        </label>
+        <label class="field">
+          <span>Correo electrónico</span>
+          <input type="email" id="reg_email" placeholder="correo@personal.com" autocomplete="email" required />
+        </label>
+        <label class="field">
+          <span>Número de teléfono</span>
+          <input type="tel" id="reg_phone" placeholder="3001234567" autocomplete="tel" required />
+        </label>
+        <label class="field">
+          <span>Contraseña</span>
+          <input type="password" id="reg_password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required />
+        </label>
+        <p id="registerError" class="error-msg" role="alert"></p>
+        <div id="registerSuccess" class="register-success" hidden>
+          <h3>Registro completado</h3>
+          <p>Tu usuario para WF TOOLS es:</p>
+          <div class="register-credentials">
+            <div><span>Usuario:</span> <strong id="registerUsername">—</strong></div>
+            <div><span>Correo:</span> <strong id="registerUserEmail">—</strong></div>
+          </div>
+          <p class="muted small-note">Usa estas credenciales junto con la contraseña creada.</p>
+        </div>
+        <button id="btnRegister" class="btn login-primary" type="submit">
+          <span class="btn-spinner" aria-hidden="true"></span>
+          <span class="btn-text">Registrar cuenta</span>
+        </button>
+        <button type="button" id="btnBackLogin" class="link-button">Volver al inicio de sesión</button>
+      </form>
+    </div>
   </div>
 
   <div id="sessionToast" class="session-toast" role="status" aria-live="polite" aria-hidden="true"></div>
@@ -120,6 +164,31 @@
     </section>
 
     <main class="grid">
+      <!-- Panel de estado de usuario -->
+      <section class="card panel span-12" id="accountPanel">
+        <h2>Estado de cuenta</h2>
+        <p id="sessionStatusText" class="session-status">Inicia sesión para ver tu plan y tus créditos en tiempo real.</p>
+        <div class="user-status">
+          <div class="user-meta">
+            <div class="meta-block">
+              <span class="meta-label">Usuario</span>
+              <span id="currentUserEmail" class="meta-value">-</span>
+            </div>
+            <div class="meta-block">
+              <span class="meta-label">Plan</span>
+              <span id="currentUserPlan" class="meta-value">-</span>
+            </div>
+          </div>
+          <div class="credit-status" id="creditStatus" data-state="idle">
+            <div class="credit-count">Créditos disponibles: <strong id="currentUserCredits">0</strong></div>
+            <div class="credit-bar" id="creditBar" role="progressbar" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
+              <div id="creditBarFill" class="credit-bar-fill"></div>
+            </div>
+            <p id="creditAlertMsg" class="credit-alert muted">Inicia sesión para visualizar tu saldo.</p>
+          </div>
+        </div>
+      </section>
+
       <!-- Panel entrada -->
       <section class="card panel span-7" id="dropZone">
         <h2>Entrada</h2>
@@ -191,31 +260,6 @@
             <span class="slider"></span><span class="lbl">JSON</span>
           </label>
           <button id="downloadBtn" class="btn" disabled>Descargar (Actual)</button>
-        </div>
-      </section>
-
-      <!-- Panel de estado de usuario -->
-      <section class="card panel span-12" id="accountPanel">
-        <h2>Estado de cuenta</h2>
-        <p id="sessionStatusText" class="session-status">Inicia sesión para ver tu plan y tus créditos en tiempo real.</p>
-        <div class="user-status">
-          <div class="user-meta">
-            <div class="meta-block">
-              <span class="meta-label">Usuario</span>
-              <span id="currentUserEmail" class="meta-value">-</span>
-            </div>
-            <div class="meta-block">
-              <span class="meta-label">Plan</span>
-              <span id="currentUserPlan" class="meta-value">-</span>
-            </div>
-          </div>
-          <div class="credit-status" id="creditStatus" data-state="idle">
-            <div class="credit-count">Créditos disponibles: <strong id="currentUserCredits">0</strong></div>
-            <div class="credit-bar" id="creditBar" role="progressbar" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0">
-              <div id="creditBarFill" class="credit-bar-fill"></div>
-            </div>
-            <p id="creditAlertMsg" class="credit-alert muted">Inicia sesión para visualizar tu saldo.</p>
-          </div>
         </div>
       </section>
 

--- a/WF-TOOLS/index.html
+++ b/WF-TOOLS/index.html
@@ -162,16 +162,6 @@
         <div class="row actions one-line">
           <div class="chip" id="planChip" style="display:none;">Plan: <span id="planName">-</span></div>
           <div class="chip" id="creditsChip" style="display:none;">Créditos: <span id="creditCount">0</span></div>
-          <button
-            id="adminPanelBtnInline"
-            class="btn admin-portal-btn admin-portal-inline"
-            type="button"
-            aria-hidden="true"
-            hidden
-          >
-            <span aria-hidden="true" class="icon">🛡️</span>
-            <span>Abrir panel administrador</span>
-          </button>
           <button id="logoutBtn" class="btn danger" style="display:none;">Cerrar sesión</button>
         </div>
       </div>
@@ -183,14 +173,41 @@
         <h2>Estado de cuenta</h2>
         <p id="sessionStatusText" class="session-status">Inicia sesión para ver tu plan y tus créditos en tiempo real.</p>
         <div class="user-status">
-          <div class="user-meta">
-            <div class="meta-block">
-              <span class="meta-label">Usuario</span>
-              <span id="currentUserEmail" class="meta-value">-</span>
+          <div class="user-overview">
+            <div class="user-meta">
+              <div class="meta-block">
+                <span class="meta-label">Nombre</span>
+                <span id="currentUserName" class="meta-value">-</span>
+              </div>
+              <div class="meta-block">
+                <span class="meta-label">Usuario / correo</span>
+                <span id="currentUserEmail" class="meta-value">-</span>
+              </div>
+              <div class="meta-block">
+                <span class="meta-label">Plan</span>
+                <span id="currentUserPlan" class="meta-value">-</span>
+              </div>
             </div>
-            <div class="meta-block">
-              <span class="meta-label">Plan</span>
-              <span id="currentUserPlan" class="meta-value">-</span>
+            <div
+              id="accountAdminShortcut"
+              class="account-admin-shortcut"
+              aria-hidden="true"
+              hidden
+            >
+              <div class="account-admin-shortcut__copy">
+                <span class="account-admin-shortcut__title">Acceso administrador</span>
+                <span class="account-admin-shortcut__hint">Gestiona usuarios, créditos y reportes desde el panel dedicado.</span>
+              </div>
+              <button
+                id="adminPanelBtnInline"
+                class="btn admin-portal-btn"
+                type="button"
+                aria-hidden="true"
+                hidden
+              >
+                <span aria-hidden="true" class="icon">🛡️</span>
+                <span>Abrir panel administrador</span>
+              </button>
             </div>
           </div>
           <div class="credit-status" id="creditStatus" data-state="idle">

--- a/WF-TOOLS/index.html
+++ b/WF-TOOLS/index.html
@@ -50,6 +50,10 @@
           </label>
         </div>
         <button id="loginBtn" class="btn login-primary">Entrar</button>
+        <button id="adminPanelBtn" class="btn admin-portal-btn" type="button" hidden>
+          <span aria-hidden="true" class="icon">🛡️</span>
+          <span>Abrir panel administrador</span>
+        </button>
         <!-- Eliminamos el botón de compra y el texto de WhatsApp.  En su lugar mostramos
              un mensaje que indica al usuario que utilice el botón flotante de recarga
              ubicado en la esquina inferior izquierda. -->

--- a/WF-TOOLS/js/auth.js
+++ b/WF-TOOLS/js/auth.js
@@ -13,6 +13,7 @@
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0a3djamhjdXF5ZXBjbHBtcHN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc5MTk4MTgsImV4cCI6MjA3MzQ5NTgxOH0.dBeJjYm12YW27LqIxon5ifPR1ygfFXAHVg8ZuCZCEf8";
 
   const supabase = global.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const REGISTRATION_TABLE = "client_registrations";
 
   const loginScreen = document.getElementById("loginScreen");
   const loginForm = document.getElementById("loginForm");
@@ -23,6 +24,20 @@
   const loginBtn = document.getElementById("loginBtn");
   const loginError = document.getElementById("loginError");
   const loginLoading = document.getElementById("loginLoading");
+  const showRegisterBtn = document.getElementById("showRegisterBtn");
+  const registerForm = document.getElementById("registerForm");
+  const registerError = document.getElementById("registerError");
+  const registerSuccess = document.getElementById("registerSuccess");
+  const registerUsername = document.getElementById("registerUsername");
+  const registerUserEmail = document.getElementById("registerUserEmail");
+  const btnBackLogin = document.getElementById("btnBackLogin");
+  const btnRegister = document.getElementById("btnRegister");
+  const btnRegisterSpinner = btnRegister?.querySelector(".btn-spinner");
+  const btnRegisterText = btnRegister?.querySelector(".btn-text");
+  const regNameInput = document.getElementById("reg_name");
+  const regEmailInput = document.getElementById("reg_email");
+  const regPhoneInput = document.getElementById("reg_phone");
+  const regPasswordInput = document.getElementById("reg_password");
   const logoutBtn = document.getElementById("logoutBtn");
   const appWrap = document.getElementById("appWrap");
   const planChip = document.getElementById("planChip");
@@ -74,6 +89,73 @@
 
   function toggleLogoutButton(disabled) {
     if (logoutBtn) logoutBtn.disabled = !!disabled;
+  }
+
+  function toggleRegisterLoading(isLoading) {
+    if (!btnRegister) return;
+    btnRegister.disabled = !!isLoading;
+    btnRegister.classList.toggle("loading", !!isLoading);
+    if (btnRegisterSpinner) {
+      btnRegisterSpinner.style.display = isLoading ? "inline-block" : "none";
+    }
+    if (btnRegisterText) {
+      btnRegisterText.style.opacity = isLoading ? "0.7" : "1";
+    }
+  }
+
+  function resetRegisterState(clearInputs = false) {
+    if (registerError) {
+      registerError.textContent = "";
+      registerError.style.display = "none";
+    }
+    if (registerSuccess) registerSuccess.hidden = true;
+    if (registerUsername) registerUsername.textContent = "—";
+    if (registerUserEmail) registerUserEmail.textContent = "—";
+    if (clearInputs) {
+      registerForm?.reset();
+    }
+  }
+
+  function showRegisterError(message) {
+    if (!registerError) return;
+    registerError.textContent = message || "";
+    registerError.style.display = message ? "block" : "none";
+  }
+
+  function setAuthMode(mode) {
+    const showRegister = mode === "register";
+    loginForm?.classList.toggle("is-hidden", showRegister);
+    registerForm?.classList.toggle("is-hidden", !showRegister);
+    if (showRegister) {
+      try {
+        regNameInput?.focus({ preventScroll: true });
+      } catch (_err) {
+        regNameInput?.focus();
+      }
+    } else {
+      try {
+        loginEmail?.focus({ preventScroll: true });
+      } catch (_err) {
+        loginEmail?.focus();
+      }
+    }
+  }
+
+  function generateClientCredentials(name) {
+    const normalized = (name || "")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase();
+    const sanitized = normalized
+      .replace(/[^a-z0-9]+/g, ".")
+      .replace(/\.\.+/g, ".")
+      .replace(/^\.|\.$/g, "")
+      .slice(0, 24);
+    const randomSuffix = Math.random().toString(36).slice(-4);
+    const base = sanitized || `usuario${randomSuffix}`;
+    const username = `clien.${base}`;
+    const wfEmail = `${username}@wftools.com`;
+    return { username, wfEmail };
   }
 
   function setSessionLoadingState(active, message) {
@@ -265,6 +347,20 @@
     loginError.style.display = message ? "block" : "none";
   }
 
+  function showRegisterSuccess(username, wfEmail) {
+    if (registerUsername) registerUsername.textContent = username || "—";
+    if (registerUserEmail) registerUserEmail.textContent = wfEmail || "—";
+    if (registerSuccess) registerSuccess.hidden = false;
+    if (wfEmail && loginEmail) {
+      loginEmail.value = wfEmail;
+    }
+    if (loginRemember && loginRemember.checked && wfEmail) {
+      setRememberedEmail(wfEmail);
+    }
+    showRegisterError("");
+    showSessionToast(`Usuario creado: ${wfEmail}`, "success");
+  }
+
   function resetLoginForm() {
     loginForm?.reset();
     showError("");
@@ -282,6 +378,59 @@
       }
     } catch (err) {
       console.warn("No se pudo recordar el correo", err);
+    }
+  }
+
+  async function handleRegisterSubmit(event) {
+    event?.preventDefault();
+    if (!btnRegister) return;
+    resetRegisterState(false);
+    const name = regNameInput?.value?.trim() || "";
+    const email = regEmailInput?.value?.trim() || "";
+    const phone = regPhoneInput?.value?.trim() || "";
+    const password = regPasswordInput?.value || "";
+
+    if (!name || !email || !phone || !password) {
+      showRegisterError("Completa todos los campos.");
+      return;
+    }
+
+    if (password.length < 8) {
+      showRegisterError("La contraseña debe tener mínimo 8 caracteres.");
+      return;
+    }
+
+    const { username, wfEmail } = generateClientCredentials(name);
+    toggleRegisterLoading(true);
+
+    try {
+      const payload = {
+        full_name: name,
+        personal_email: email,
+        phone_number: phone,
+        plain_password: password,
+        wf_username: username,
+        wf_email: wfEmail,
+        created_at: new Date().toISOString(),
+      };
+
+      const { error } = await supabase
+        .from(REGISTRATION_TABLE)
+        .insert([payload], { returning: "minimal" });
+
+      if (error) {
+        console.error("Error registrando cliente", error);
+        showRegisterError(error.message || "No se pudo completar el registro.");
+        return;
+      }
+
+      registerForm?.reset();
+      showRegisterSuccess(username, wfEmail);
+    } catch (err) {
+      console.error("Fallo general en registro", err);
+      showRegisterError("Ocurrió un error registrando tu cuenta.");
+    } finally {
+      toggleRegisterLoading(false);
     }
   }
 
@@ -340,6 +489,9 @@
     setSessionLoadingState(false);
     if (appWrap) appWrap.style.display = "none";
     if (loginScreen) loginScreen.style.display = "flex";
+    setAuthMode("login");
+    resetRegisterState(true);
+    toggleRegisterLoading(false);
     clearCreditsUI();
     resetLoginForm();
     updateUserIdentity(null);
@@ -477,10 +629,24 @@
 
   async function init() {
     global.AppCore?.setCreditDependentActionsEnabled(false);
+    resetRegisterState(true);
+    setAuthMode("login");
+    toggleRegisterLoading(false);
     loginForm?.addEventListener("submit", handleLoginSubmit);
+    registerForm?.addEventListener("submit", handleRegisterSubmit);
     logoutBtn?.addEventListener("click", handleLogout);
     restoreRememberedEmail();
     resetPasswordToggle();
+
+    showRegisterBtn?.addEventListener("click", () => {
+      resetRegisterState(false);
+      setAuthMode("register");
+    });
+
+    btnBackLogin?.addEventListener("click", () => {
+      setAuthMode("login");
+      showRegisterError("");
+    });
 
     if (!storageAvailable && loginRemember) {
       loginRemember.checked = false;

--- a/WF-TOOLS/js/auth.js
+++ b/WF-TOOLS/js/auth.js
@@ -13,8 +13,6 @@
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0a3djamhjdXF5ZXBjbHBtcHN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc5MTk4MTgsImV4cCI6MjA3MzQ5NTgxOH0.dBeJjYm12YW27LqIxon5ifPR1ygfFXAHVg8ZuCZCEf8";
 
   const supabase = global.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-  const REGISTRATION_TABLE = "client_registrations";
-  const ADMIN_PANEL_URL = "../Panel%20Admin/index.html";
 
   const loginScreen = document.getElementById("loginScreen");
   const loginForm = document.getElementById("loginForm");
@@ -23,32 +21,14 @@
   const loginTogglePassword = document.getElementById("loginTogglePassword");
   const loginRemember = document.getElementById("loginRemember");
   const loginBtn = document.getElementById("loginBtn");
-  const adminPortalBtn = document.getElementById("adminPanelBtn");
-  const adminPortalInlineBtn = document.getElementById("adminPanelBtnInline");
-  const adminPortalButtons = [adminPortalBtn, adminPortalInlineBtn].filter(Boolean);
   const loginError = document.getElementById("loginError");
   const loginLoading = document.getElementById("loginLoading");
-  const showRegisterBtn = document.getElementById("showRegisterBtn");
-  const registerForm = document.getElementById("registerForm");
-  const registerError = document.getElementById("registerError");
-  const registerSuccess = document.getElementById("registerSuccess");
-  const registerUsername = document.getElementById("registerUsername");
-  const registerUserEmail = document.getElementById("registerUserEmail");
-  const btnBackLogin = document.getElementById("btnBackLogin");
-  const btnRegister = document.getElementById("btnRegister");
-  const btnRegisterSpinner = btnRegister?.querySelector(".btn-spinner");
-  const btnRegisterText = btnRegister?.querySelector(".btn-text");
-  const regNameInput = document.getElementById("reg_name");
-  const regEmailInput = document.getElementById("reg_email");
-  const regPhoneInput = document.getElementById("reg_phone");
-  const regPasswordInput = document.getElementById("reg_password");
   const logoutBtn = document.getElementById("logoutBtn");
   const appWrap = document.getElementById("appWrap");
   const planChip = document.getElementById("planChip");
   const planNameEl = document.getElementById("planName");
   const creditsChip = document.getElementById("creditsChip");
   const creditCountEl = document.getElementById("creditCount");
-  const userNameEl = document.getElementById("currentUserName");
   const userEmailEl = document.getElementById("currentUserEmail");
   const userPlanEl = document.getElementById("currentUserPlan");
   const userCreditsEl = document.getElementById("currentUserCredits");
@@ -65,14 +45,11 @@
   const bodyEl = document.body;
   const sessionLoading = document.getElementById("sessionLoading");
   const sessionLoadingMessage = document.getElementById("sessionLoadingMessage");
-  const accountAdminShortcut = document.getElementById("accountAdminShortcut");
 
   let lastCreditsValue = null;
   let maxCreditsSeen = 0;
   let toastTimeout = null;
   let pendingWelcomeEmail = null;
-  let currentUserId = null;
-  let currentUserEmail = null;
   const creditFormatter = new Intl.NumberFormat("es-CO");
   const REMEMBER_KEY = "wf-tools.login.remembered-email";
   const STORAGE_TEST_KEY = "wf-tools.login.storage-test";
@@ -97,113 +74,6 @@
 
   function toggleLogoutButton(disabled) {
     if (logoutBtn) logoutBtn.disabled = !!disabled;
-  }
-
-  function toggleRegisterLoading(isLoading) {
-    if (!btnRegister) return;
-    btnRegister.disabled = !!isLoading;
-    btnRegister.classList.toggle("loading", !!isLoading);
-    if (btnRegisterSpinner) {
-      btnRegisterSpinner.style.display = isLoading ? "inline-block" : "none";
-    }
-    if (btnRegisterText) {
-      btnRegisterText.style.opacity = isLoading ? "0.7" : "1";
-    }
-  }
-
-  function resetRegisterState(clearInputs = false) {
-    if (registerError) {
-      registerError.textContent = "";
-      registerError.style.display = "none";
-    }
-    if (registerSuccess) registerSuccess.hidden = true;
-    if (registerUsername) registerUsername.textContent = "—";
-    if (registerUserEmail) registerUserEmail.textContent = "—";
-    if (clearInputs) {
-      registerForm?.reset();
-    }
-  }
-
-  function showRegisterError(message) {
-    if (!registerError) return;
-    registerError.textContent = message || "";
-    registerError.style.display = message ? "block" : "none";
-  }
-
-  function setAuthMode(mode) {
-    const showRegister = mode === "register";
-    loginForm?.classList.toggle("is-hidden", showRegister);
-    registerForm?.classList.toggle("is-hidden", !showRegister);
-    if (showRegister) {
-      try {
-        regNameInput?.focus({ preventScroll: true });
-      } catch (_err) {
-        regNameInput?.focus();
-      }
-    } else {
-      try {
-        loginEmail?.focus({ preventScroll: true });
-      } catch (_err) {
-        loginEmail?.focus();
-      }
-    }
-  }
-
-  function generateClientCredentials(name) {
-    const normalized = (name || "")
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "")
-      .toLowerCase();
-    const sanitized = normalized
-      .replace(/[^a-z0-9]+/g, ".")
-      .replace(/\.\.+/g, ".")
-      .replace(/^\.|\.$/g, "")
-      .slice(0, 24);
-    const randomSuffix = Math.random().toString(36).slice(-4);
-    const base = sanitized || `usuario${randomSuffix}`;
-    const username = `clien.${base}`;
-    const wfEmail = `${username}@wftools.com`;
-    return { username, wfEmail };
-  }
-
-  function isAdminEmail(email) {
-    if (!email) return false;
-    const local = String(email).split("@")[0]?.toLowerCase() || "";
-    return /^(admin|sup)\./.test(local);
-  }
-
-  function toggleAdminButton(button, show) {
-    if (!button) return;
-    button.hidden = !show;
-    button.setAttribute("aria-hidden", show ? "false" : "true");
-    button.disabled = !show;
-  }
-
-  function syncAdminPortalAccess(email) {
-    const show = isAdminEmail(email);
-    adminPortalButtons.forEach((button) => toggleAdminButton(button, show));
-    if (accountAdminShortcut) {
-      accountAdminShortcut.hidden = !show;
-      accountAdminShortcut.setAttribute("aria-hidden", show ? "false" : "true");
-    }
-  }
-
-  function navigateToAdminPanel(event) {
-    if (event) {
-      if (typeof event.preventDefault === "function") event.preventDefault();
-      if (typeof event.stopPropagation === "function") event.stopPropagation();
-    }
-
-    try {
-      if (global.self !== global.top && global.parent && typeof global.parent.showFrame === "function") {
-        global.parent.showFrame("adminFrame");
-        return;
-      }
-    } catch (_err) {
-      /* ignored */
-    }
-
-    global.location.href = ADMIN_PANEL_URL;
   }
 
   function setSessionLoadingState(active, message) {
@@ -316,26 +186,7 @@
   });
 
   function updateUserIdentity(user) {
-    currentUserId = user?.id || null;
-    currentUserEmail = user?.email || null;
     if (userEmailEl) userEmailEl.textContent = user?.email || "-";
-    if (userNameEl) {
-      const metadata = user?.user_metadata || {};
-      const rawName =
-        metadata.full_name ||
-        metadata.fullName ||
-        metadata.name ||
-        metadata.display_name ||
-        null;
-      if (rawName) {
-        userNameEl.textContent = rawName;
-      } else if (user?.email) {
-        userNameEl.textContent = user.email.split("@")[0] || user.email;
-      } else {
-        userNameEl.textContent = "-";
-      }
-    }
-    syncAdminPortalAccess(user?.email || null);
   }
 
   function renderCreditState(rawCredits) {
@@ -414,20 +265,6 @@
     loginError.style.display = message ? "block" : "none";
   }
 
-  function showRegisterSuccess(username, wfEmail) {
-    if (registerUsername) registerUsername.textContent = username || "—";
-    if (registerUserEmail) registerUserEmail.textContent = wfEmail || "—";
-    if (registerSuccess) registerSuccess.hidden = false;
-    if (wfEmail && loginEmail) {
-      loginEmail.value = wfEmail;
-    }
-    if (loginRemember && loginRemember.checked && wfEmail) {
-      setRememberedEmail(wfEmail);
-    }
-    showRegisterError("");
-    showSessionToast(`Usuario creado: ${wfEmail}`, "success");
-  }
-
   function resetLoginForm() {
     loginForm?.reset();
     showError("");
@@ -435,13 +272,6 @@
     toggleLoginButton(false);
     restoreRememberedEmail();
     resetPasswordToggle();
-    if (!loginRemember?.checked) {
-      if (currentUserEmail) {
-        syncAdminPortalAccess(currentUserEmail);
-      } else {
-        syncAdminPortalAccess(null);
-      }
-    }
   }
 
   function setRememberedEmail(value) {
@@ -452,59 +282,6 @@
       }
     } catch (err) {
       console.warn("No se pudo recordar el correo", err);
-    }
-  }
-
-  async function handleRegisterSubmit(event) {
-    event?.preventDefault();
-    if (!btnRegister) return;
-    resetRegisterState(false);
-    const name = regNameInput?.value?.trim() || "";
-    const email = regEmailInput?.value?.trim() || "";
-    const phone = regPhoneInput?.value?.trim() || "";
-    const password = regPasswordInput?.value || "";
-
-    if (!name || !email || !phone || !password) {
-      showRegisterError("Completa todos los campos.");
-      return;
-    }
-
-    if (password.length < 8) {
-      showRegisterError("La contraseña debe tener mínimo 8 caracteres.");
-      return;
-    }
-
-    const { username, wfEmail } = generateClientCredentials(name);
-    toggleRegisterLoading(true);
-
-    try {
-      const payload = {
-        full_name: name,
-        personal_email: email,
-        phone_number: phone,
-        plain_password: password,
-        wf_username: username,
-        wf_email: wfEmail,
-        created_at: new Date().toISOString(),
-      };
-
-      const { error } = await supabase
-        .from(REGISTRATION_TABLE)
-        .insert([payload], { returning: "minimal" });
-
-      if (error) {
-        console.error("Error registrando cliente", error);
-        showRegisterError(error.message || "No se pudo completar el registro.");
-        return;
-      }
-
-      registerForm?.reset();
-      showRegisterSuccess(username, wfEmail);
-    } catch (err) {
-      console.error("Fallo general en registro", err);
-      showRegisterError("Ocurrió un error registrando tu cuenta.");
-    } finally {
-      toggleRegisterLoading(false);
     }
   }
 
@@ -527,10 +304,8 @@
       } else if (loginRemember) {
         loginRemember.checked = false;
       }
-      syncAdminPortalAccess(loginEmail.value.trim());
     } catch (err) {
       if (loginRemember) loginRemember.checked = false;
-      syncAdminPortalAccess(null);
     }
   }
 
@@ -551,7 +326,6 @@
       planChip.className = "chip";
     }
     if (planNameEl) planNameEl.textContent = "-";
-    if (userNameEl) userNameEl.textContent = "-";
     if (userPlanEl) userPlanEl.textContent = "-";
     if (creditsChip) creditsChip.style.display = "none";
     renderCreditState(null);
@@ -560,18 +334,12 @@
       logoutBtn.disabled = false;
     }
     global.AppCore?.setCreditDependentActionsEnabled(false);
-    syncAdminPortalAccess(null);
-    currentUserId = null;
-    currentUserEmail = null;
   }
 
   function showLoginUI(message, state) {
     setSessionLoadingState(false);
     if (appWrap) appWrap.style.display = "none";
     if (loginScreen) loginScreen.style.display = "flex";
-    setAuthMode("login");
-    resetRegisterState(true);
-    toggleRegisterLoading(false);
     clearCreditsUI();
     resetLoginForm();
     updateUserIdentity(null);
@@ -589,10 +357,6 @@
     if (loginScreen) loginScreen.style.display = "none";
     if (appWrap) appWrap.style.display = "block";
     resetLoginForm();
-    if (logoutBtn) {
-      logoutBtn.style.display = "inline-block";
-      logoutBtn.disabled = false;
-    }
   }
 
   function applyCredits(profile) {
@@ -600,12 +364,6 @@
     const planName = profile.plan || "-";
     if (planNameEl) planNameEl.textContent = planName;
     if (userPlanEl) userPlanEl.textContent = planName;
-    if (userNameEl) {
-      const fullName = profile.full_name;
-      if (fullName && typeof fullName === "string" && fullName.trim()) {
-        userNameEl.textContent = fullName.trim();
-      }
-    }
     if (planChip) {
       const planClass = planName.toLowerCase();
       planChip.className = "chip" + (planClass ? " plan-" + planClass : "");
@@ -620,75 +378,14 @@
   }
 
   async function updateCredits() {
-    let userId = currentUserId;
-    let email = currentUserEmail;
-
-    if (!userId || !email) {
-      try {
-        const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
-
-        if (sessionError) {
-          console.error("No se pudo obtener la sesión para actualizar créditos", sessionError);
-        }
-
-        if (session?.user) {
-          userId = session.user.id;
-          email = session.user.email || email || null;
-          updateUserIdentity(session.user);
-        }
-      } catch (err) {
-        console.error("Error verificando el usuario activo para créditos", err);
-      }
-    }
-
-    if (!userId && !email) {
-      console.warn("No hay usuario activo para actualizar créditos.");
-      if (logoutBtn) logoutBtn.style.display = "inline-block";
+    const { data: profile, error } = await supabase
+      .from("profiles")
+      .select("plan, credits")
+      .single();
+    if (error) {
+      console.error("Perfil", error);
       return;
     }
-
-    const fetchProfile = async (label, builder) => {
-      try {
-        let query = supabase.from("profiles").select("plan, credits, full_name, email").limit(1);
-        if (typeof builder === "function") {
-          query = builder(query);
-        }
-        const { data, error } = await query.maybeSingle();
-        if (error && error.code !== "PGRST116") {
-          console.error(`Error obteniendo perfil (${label})`, error);
-        }
-        if (data) {
-          return data;
-        }
-      } catch (err) {
-        console.error(`Fallo obteniendo perfil (${label})`, err);
-      }
-      return null;
-    };
-
-    let profile = null;
-    if (userId) {
-      profile = await fetchProfile("por id", (query) => query.eq("id", userId));
-    }
-    if (!profile && email) {
-      profile = await fetchProfile("por email", (query) => query.eq("email", email));
-    }
-    if (!profile) {
-      profile = await fetchProfile("general");
-    }
-
-    if (!profile) {
-      console.warn("No se encontró un perfil para la cuenta actual.");
-      renderCreditState(null);
-      if (planChip) planChip.style.display = "none";
-      if (creditsChip) creditsChip.style.display = "none";
-      if (logoutBtn) logoutBtn.style.display = "inline-block";
-      return;
-    }
-
     applyCredits(profile);
   }
 
@@ -780,39 +477,16 @@
 
   async function init() {
     global.AppCore?.setCreditDependentActionsEnabled(false);
-    resetRegisterState(true);
-    setAuthMode("login");
-    toggleRegisterLoading(false);
     loginForm?.addEventListener("submit", handleLoginSubmit);
-    registerForm?.addEventListener("submit", handleRegisterSubmit);
     logoutBtn?.addEventListener("click", handleLogout);
     restoreRememberedEmail();
     resetPasswordToggle();
-
-    showRegisterBtn?.addEventListener("click", () => {
-      resetRegisterState(false);
-      setAuthMode("register");
-    });
-
-    btnBackLogin?.addEventListener("click", () => {
-      setAuthMode("login");
-      showRegisterError("");
-    });
 
     if (!storageAvailable && loginRemember) {
       loginRemember.checked = false;
       loginRemember.disabled = true;
       loginRemember.closest?.(".remember-option")?.classList.add("is-disabled");
     }
-
-    loginEmail?.addEventListener("input", () => {
-      const email = loginEmail.value.trim();
-      if (!email && !loginRemember?.checked) {
-        syncAdminPortalAccess(null);
-        return;
-      }
-      syncAdminPortalAccess(email);
-    });
 
     loginEmail?.addEventListener("blur", () => {
       const email = loginEmail.value.trim();
@@ -824,15 +498,11 @@
     loginRemember?.addEventListener("change", () => {
       if (!loginRemember.checked) {
         clearRememberedEmail();
-        if (!loginEmail?.value.trim()) {
-          syncAdminPortalAccess(null);
-        }
         return;
       }
       const email = loginEmail?.value.trim();
       if (email) {
         setRememberedEmail(email);
-        syncAdminPortalAccess(email);
       }
     });
 
@@ -853,10 +523,6 @@
           loginPassword.focus();
         }
       }
-    });
-
-    adminPortalButtons.forEach((button) => {
-      button.addEventListener("click", navigateToAdminPanel);
     });
 
     setSessionLoadingState(true, "Verificando tu sesión...");

--- a/WF-TOOLS/js/auth.js
+++ b/WF-TOOLS/js/auth.js
@@ -24,6 +24,8 @@
   const loginRemember = document.getElementById("loginRemember");
   const loginBtn = document.getElementById("loginBtn");
   const adminPortalBtn = document.getElementById("adminPanelBtn");
+  const adminPortalInlineBtn = document.getElementById("adminPanelBtnInline");
+  const adminPortalButtons = [adminPortalBtn, adminPortalInlineBtn].filter(Boolean);
   const loginError = document.getElementById("loginError");
   const loginLoading = document.getElementById("loginLoading");
   const showRegisterBtn = document.getElementById("showRegisterBtn");
@@ -166,12 +168,34 @@
     return local.startsWith("admin.");
   }
 
+  function toggleAdminButton(button, show) {
+    if (!button) return;
+    button.hidden = !show;
+    button.setAttribute("aria-hidden", show ? "false" : "true");
+    button.disabled = !show;
+  }
+
   function syncAdminPortalAccess(email) {
-    if (!adminPortalBtn) return;
     const show = isAdminEmail(email);
-    adminPortalBtn.hidden = !show;
-    adminPortalBtn.setAttribute("aria-hidden", show ? "false" : "true");
-    adminPortalBtn.disabled = !show;
+    adminPortalButtons.forEach((button) => toggleAdminButton(button, show));
+  }
+
+  function navigateToAdminPanel(event) {
+    if (event) {
+      if (typeof event.preventDefault === "function") event.preventDefault();
+      if (typeof event.stopPropagation === "function") event.stopPropagation();
+    }
+
+    try {
+      if (global.self !== global.top && global.parent && typeof global.parent.showFrame === "function") {
+        global.parent.showFrame("adminFrame");
+        return;
+      }
+    } catch (_err) {
+      /* ignored */
+    }
+
+    global.location.href = ADMIN_PANEL_URL;
   }
 
   function setSessionLoadingState(active, message) {
@@ -727,15 +751,8 @@
       }
     });
 
-    adminPortalBtn?.addEventListener("click", () => {
-      try {
-        const newTab = window.open(ADMIN_PANEL_URL, "_blank", "noopener");
-        if (!newTab) {
-          window.location.href = ADMIN_PANEL_URL;
-        }
-      } catch (_err) {
-        window.location.href = ADMIN_PANEL_URL;
-      }
+    adminPortalButtons.forEach((button) => {
+      button.addEventListener("click", navigateToAdminPanel);
     });
 
     setSessionLoadingState(true, "Verificando tu sesión...");

--- a/WF-TOOLS/js/auth.js
+++ b/WF-TOOLS/js/auth.js
@@ -167,7 +167,7 @@
   function isAdminEmail(email) {
     if (!email) return false;
     const local = String(email).split("@")[0]?.toLowerCase() || "";
-    return local.startsWith("admin.");
+    return /^(admin|sup)\./.test(local);
   }
 
   function toggleAdminButton(button, show) {

--- a/WF-TOOLS/styles.css
+++ b/WF-TOOLS/styles.css
@@ -2116,6 +2116,48 @@ body[data-theme="light"] .session-modal-icon{
 .login-primary:active{ transform: translateY(0); }
 .login-primary:disabled{ opacity:.55; cursor:not-allowed; }
 
+.admin-portal-btn{
+  margin-top:12px;
+  background: linear-gradient(135deg, rgba(14,165,233,.22), rgba(56,189,248,.32));
+  color:#e0f2fe;
+  border:1px solid rgba(56,189,248,.45);
+  box-shadow:0 14px 32px rgba(14,165,233,.28);
+  font-weight:700;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  width:100%;
+  transition: transform .12s ease, box-shadow .18s ease, background .18s ease;
+}
+
+.admin-portal-btn .icon{
+  font-size:1.1rem;
+  filter: drop-shadow(0 2px 6px rgba(14,165,233,.35));
+}
+
+.admin-portal-btn:hover{
+  transform:translateY(-1px);
+  box-shadow:0 18px 36px rgba(14,165,233,.32);
+}
+
+.admin-portal-btn:focus-visible{
+  outline:3px solid rgba(14,165,233,.45);
+  outline-offset:3px;
+}
+
+.admin-portal-btn[hidden]{
+  display:none !important;
+}
+
+[data-theme="light"] .admin-portal-btn,
+html[data-theme="light"] .admin-portal-btn{
+  background: linear-gradient(135deg, rgba(14,165,233,.18), rgba(3,105,161,.24));
+  color:#0b1f33;
+  border-color: rgba(14,165,233,.38);
+  box-shadow:0 14px 30px rgba(14,165,233,.18);
+}
+
 .login-buy{
   border:1px solid var(--border);
   background: rgba(255,255,255,.05);

--- a/WF-TOOLS/styles.css
+++ b/WF-TOOLS/styles.css
@@ -1792,6 +1792,22 @@ body[data-theme="light"] .session-modal-icon{
   box-shadow:0 16px 32px rgba(16,185,129,.18);
 }
 
+.login-card-stack{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:clamp(18px, 3vw, 26px);
+  width:min(92vw, 440px);
+}
+
+.login-card-stack .login-card{
+  width:100%;
+}
+
+.login-card.is-hidden{
+  display:none;
+}
+
 .login-screen{
   position:fixed;
   inset:0;
@@ -1842,6 +1858,100 @@ body[data-theme="light"] .session-modal-icon{
 .login-card .field span{
   font-weight:700;
   color: var(--text-2);
+}
+
+.login-links{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  align-items:center;
+}
+
+.link-button{
+  background:none;
+  border:none;
+  color:var(--pri);
+  font-weight:700;
+  cursor:pointer;
+  text-decoration:underline;
+  padding:6px 8px;
+  font-size:1rem;
+}
+
+.link-button:focus-visible{
+  outline:2px solid var(--pri);
+  outline-offset:3px;
+}
+
+[data-theme="light"] .link-button{
+  color:var(--sec);
+}
+
+.register-intro{
+  margin:0;
+  line-height:1.45;
+  color:var(--text-2);
+}
+
+.register-success{
+  border:1px solid rgba(34,197,94,.35);
+  background:rgba(34,197,94,.08);
+  border-radius:16px;
+  padding:14px 16px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+[data-theme="light"] .register-success{
+  background:rgba(34,197,94,.12);
+  border-color:rgba(22,163,74,.32);
+}
+
+.register-success h3{
+  margin:0;
+  font-size:1.05rem;
+  color:var(--success);
+}
+
+.register-success p{
+  margin:0;
+}
+
+.register-credentials{
+  display:grid;
+  gap:6px;
+  font-size:0.95rem;
+}
+
+.register-credentials span{
+  color:var(--text-2);
+  font-weight:600;
+  margin-right:4px;
+}
+
+.register-success[hidden]{
+  display:none;
+}
+
+.btn-spinner{
+  width:16px;
+  height:16px;
+  border-radius:50%;
+  border:2px solid rgba(14,165,233,.25);
+  border-top-color:var(--pri);
+  border-right-color:var(--pri);
+  display:none;
+  margin-right:10px;
+  animation:spin .8s linear infinite;
+}
+
+.btn.login-primary.loading .btn-spinner{
+  display:inline-block;
+}
+
+.btn.login-primary.loading .btn-text{
+  opacity:.65;
 }
 
 #loginEmail,
@@ -2271,4 +2381,9 @@ body[data-theme="light"] .title-logo{
   width: 40px;
   height: 40px;
   margin-bottom: 6px;
+}
+
+@keyframes spin{
+  0%{ transform:rotate(0deg); }
+  100%{ transform:rotate(360deg); }
 }

--- a/WF-TOOLS/styles.css
+++ b/WF-TOOLS/styles.css
@@ -1277,14 +1277,67 @@ body[data-theme="light"] .table thead th{
   align-items:stretch;
 }
 
+#accountPanel .user-overview{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
 @media (max-width: 1200px){
   #accountPanel .user-status{ grid-template-columns:1fr; }
+  #accountPanel .user-overview{ order:0; }
 }
 
 #accountPanel .user-meta{
   display:grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap:12px;
+}
+
+#accountPanel .account-admin-shortcut{
+  display:flex;
+  align-items:center;
+  gap:18px;
+  padding:16px 18px;
+  border-radius:var(--radius-sm);
+  border:1px dashed rgba(56,189,248,.45);
+  background: linear-gradient(135deg, rgba(14,165,233,.14), rgba(14,165,233,.05));
+  box-shadow: inset 0 0 0 1px rgba(14,165,233,.08);
+}
+
+#accountPanel .account-admin-shortcut[hidden]{
+  display:none !important;
+}
+
+#accountPanel .account-admin-shortcut__copy{
+  flex:1 1 200px;
+  color: var(--text-2);
+  font-size:.92rem;
+  line-height:1.45;
+}
+
+#accountPanel .account-admin-shortcut__title{
+  display:block;
+  font-weight:700;
+  color: var(--text-1);
+  margin-bottom:4px;
+}
+
+#accountPanel .account-admin-shortcut .admin-portal-btn{
+  margin-top:0;
+  max-width:260px;
+  white-space:nowrap;
+}
+
+@media (max-width: 780px){
+  #accountPanel .account-admin-shortcut{
+    flex-direction:column;
+    align-items:stretch;
+  }
+  #accountPanel .account-admin-shortcut .admin-portal-btn{
+    max-width:none;
+    width:100%;
+  }
 }
 
 #accountPanel .meta-block{

--- a/WF-TOOLS/styles.css
+++ b/WF-TOOLS/styles.css
@@ -2158,6 +2158,24 @@ html[data-theme="light"] .admin-portal-btn{
   box-shadow:0 14px 30px rgba(14,165,233,.18);
 }
 
+.admin-portal-inline{
+  margin-top:0;
+  width:auto;
+  min-width:0;
+  padding:0 18px;
+  white-space:nowrap;
+}
+
+.topbar .actions.one-line .admin-portal-inline{
+  flex-shrink:0;
+}
+
+@media (max-width:720px){
+  .row.actions.one-line .admin-portal-inline{
+    width:100%;
+  }
+}
+
 .login-buy{
   border:1px solid var(--border);
   background: rgba(255,255,255,.05);

--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
 
     <title>WF-TOOLS</title>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- Favicon principal -->
     <link rel="icon" type="image/png" sizes="32x32" href="WF-TOOLS/WF%20TOOLS%202.png" />
 
@@ -33,7 +40,7 @@
         overflow: hidden; /* Evita scroll del contenedor unificado */
         background: #000;
         color: var(--text);
-        font-family: ui-sans-serif, system-ui, "Segoe UI", Roboto, Ubuntu, Cantarell, Arial;
+        font-family: 'Space Grotesk', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', 'Helvetica Neue', Arial;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         text-rendering: optimizeLegibility;
@@ -290,6 +297,7 @@
       .boot-title{
         margin:0 0 12px 0; display:flex; align-items:center; gap:12px;
         font-weight:800; font-size:22px; letter-spacing:.4px; line-height:1.15;
+        font-family: 'Space Grotesk', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', 'Helvetica Neue', Arial;
         background: linear-gradient(90deg, var(--brand-a), var(--brand-b));
         -webkit-background-clip: text; background-clip:text; color: transparent;
         text-shadow: 0 0 18px rgba(33,228,255,.18);
@@ -613,15 +621,23 @@
         try {
           const wfFrame = document.getElementById('wfFrame');
           const wfDoc   = wfFrame.contentDocument || wfFrame.contentWindow.document;
-          const adminBtn = wfDoc && wfDoc.getElementById('adminAccessBtn');
-          if (!adminBtn) return;
+          if (!wfDoc) return;
 
-          adminBtn.onclick = function (e) {
+          const intercept = function (e) {
+            if (!e) return;
             e.preventDefault();
-            e.stopPropagation();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+            if (typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation();
             showFrame('adminFrame');
             return false;
           };
+
+          ['adminAccessBtn', 'adminPanelBtn', 'adminPanelBtnInline'].forEach((id) => {
+            const button = wfDoc.getElementById(id);
+            if (!button || button.dataset.wfAdminIntercept === 'true') return;
+            button.addEventListener('click', intercept, true);
+            button.dataset.wfAdminIntercept = 'true';
+          });
         } catch (err) {
           console.error('No se pudo interceptar el botón de administrador:', err);
         }

--- a/index.html
+++ b/index.html
@@ -560,7 +560,9 @@
       }
 
       /* ===== Alterna vista activa y controla widgets ===== */
-      function showFrame(frameId) {
+      function showFrame(frameId, options) {
+        const opts = options || {};
+        const shouldReload = !!opts.reload;
         showLoading();
 
         const frames = ['wfFrame', 'adminFrame', 'landingFrame'];
@@ -594,7 +596,32 @@
               try { setupAdminIntercept(); } catch (_) {}
             }
 
-            setTimeout(() => hideLoading(), 500);
+            if (shouldReload) {
+              let fallbackTimer = null;
+              const handleLoad = () => {
+                if (fallbackTimer !== null) clearTimeout(fallbackTimer);
+                frame.removeEventListener('load', handleLoad);
+                hideLoading();
+              };
+              fallbackTimer = setTimeout(() => {
+                frame.removeEventListener('load', handleLoad);
+                hideLoading();
+              }, 2600);
+              frame.addEventListener('load', handleLoad, { once: true });
+              try {
+                if (frame.contentWindow && typeof frame.contentWindow.location.reload === 'function') {
+                  frame.contentWindow.location.reload();
+                } else {
+                  const src = frame.getAttribute('src');
+                  if (src) frame.setAttribute('src', src);
+                }
+              } catch (_err) {
+                const src = frame.getAttribute('src');
+                if (src) frame.setAttribute('src', src);
+              }
+            } else {
+              setTimeout(() => hideLoading(), 500);
+            }
           } else {
             frame.classList.remove('active');
           }


### PR DESCRIPTION
## Summary
- add a registration view for new WF-TOOLS clients with Supabase persistence
- surface an Estado de cuenta card under the admin header showing the signed-in admin and credit metrics
- wire up helper utilities to generate WF Tools credentials and drive Supabase-backed registration UX

## Testing
- not run (frontend-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d026d85cd08330a196683bfeca9602